### PR TITLE
feat: kratix update destination-selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@ To add Promise dependencies, you can run the `kratix update dependencies depende
 kratix update dependencies DEPENDENCIES-DIRECTORY/
 ```
 
+### Updating Destination selectors
+
+To update Destination selectors of the Promise, you can use the `kratix update destination-selector` command:
+```
+kratix update destination-selector env=dev
+```
+
 ### Building Promise
 
 If you initialized the Promise by providing `--split` flag in `kratix init promise` command, run

--- a/cmd/update_destination_selector.go
+++ b/cmd/update_destination_selector.go
@@ -1,0 +1,63 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/syntasso/kratix/api/v1alpha1"
+	"os"
+	"path/filepath"
+	"sigs.k8s.io/yaml"
+	"strings"
+)
+
+var updateDestinationSelector = &cobra.Command{
+	Use:   "destination-selector KEY=VALUE",
+	Short: "Command to update destination selectors",
+	Long:  "Command to update destination selectors",
+	Example: `  # adds and updates a destination selector
+  kratix update destination-selector env=dev
+  # removes an existing destination selector
+  kratix update destination-selector zone-
+`,
+	RunE: UpdateSelector,
+	Args: cobra.ExactArgs(1),
+}
+
+func init() {
+	updateCmd.AddCommand(updateDestinationSelector)
+	updateDestinationSelector.Flags().StringVarP(&dir, "dir", "d", ".", "Directory to read Promise from")
+}
+
+func UpdateSelector(cmd *cobra.Command, args []string) error {
+	var promise v1alpha1.Promise
+	if promise, err = getPromise(filepath.Join(dir, "promise.yaml")); err != nil {
+		return fmt.Errorf("failed to find promise.yaml in directory: %v", err)
+	}
+
+	if parsed := strings.Split(args[0], "="); len(parsed) == 2 {
+		if len(promise.Spec.DestinationSelectors) == 0 {
+			promise.Spec.DestinationSelectors = []v1alpha1.PromiseScheduling{{MatchLabels: map[string]string{}}}
+		}
+		key, value := parsed[0], parsed[1]
+		promise.Spec.DestinationSelectors[0].MatchLabels[key] = value
+	} else {
+		if args[0][len(args[0])-1:] != "-" {
+			return fmt.Errorf("invalid destination key: %s", args[0])
+		}
+		key := strings.TrimRight(args[0], "-")
+		if len(promise.Spec.DestinationSelectors) > 0 {
+			delete(promise.Spec.DestinationSelectors[0].MatchLabels, key)
+		}
+	}
+
+	var promiseBytes []byte
+	if promiseBytes, err = yaml.Marshal(promise); err != nil {
+		return err
+	}
+	if err = os.WriteFile(filepath.Join(dir, "promise.yaml"), promiseBytes, filePerm); err != nil {
+		return err
+	}
+
+	fmt.Println("Promise destination selector updated")
+	return nil
+}


### PR DESCRIPTION
## Changes
Implement `kratix update selector` which updates destination selectors in promise.yaml

```
kratix update destination-selector env=test
kratix update destination-selector kubernetes.io/hostname=platform-control-plane
```

promise.yaml updated and will look like
```yaml
apiVersion: platform.kratix.io/v1alpha1
kind: Promise
metadata:
  name: pipeline-ns
spec:
  api:
...
  destinationSelectors:
  - matchLabels:
      env: test
      kubernetes.io/hostname: platform-control-plane
  workflows:
...
```