### PR TITLE
feat: improvements to add container cmd

### DIFF
--- a/cmd/add_container.go
+++ b/cmd/add_container.go
@@ -159,7 +159,6 @@ func AddContainer(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if err := generatePipelineDirFiles(dir, workflowPath, pipelineName, containerName); err != nil {
-		fmt.Println(dir, workflowPath, pipelineName, containerName)
 		return err
 	}
 

--- a/cmd/init_promise.go
+++ b/cmd/init_promise.go
@@ -1,14 +1,10 @@
 package cmd
 
 import (
-	"bytes"
 	"embed"
 	"fmt"
-	"os"
-	"strings"
-	"text/template"
-
 	"github.com/spf13/cobra"
+	"strings"
 )
 
 //go:embed templates/promise/*
@@ -75,29 +71,17 @@ func templatePromiseFiles(promiseName, subcommand string) error {
 		templates[promiseFileName] = "templates/promise/promise.yaml.tpl"
 	}
 
-	for name, tmpl := range templates {
-		t, err := template.ParseFS(promiseTemplates, tmpl)
-		if err != nil {
-			return err
-		}
-		data := bytes.NewBuffer([]byte{})
-		err = t.Execute(data, promiseTemplateValues{
-			Name:       promiseName,
-			Group:      group,
-			Kind:       kind,
-			Version:    version,
-			Plural:     plural,
-			Singular:   strings.ToLower(kind),
-			SubCommand: subcommand,
-		})
-		if err != nil {
-			return err
-		}
-
-		err = os.WriteFile(fmt.Sprintf("%s/%s", outputDir, name), data.Bytes(), filePerm)
-		if err != nil {
-			return err
-		}
+	templateValues := promiseTemplateValues{
+		Name:       promiseName,
+		Group:      group,
+		Kind:       kind,
+		Version:    version,
+		Plural:     plural,
+		Singular:   strings.ToLower(kind),
+		SubCommand: subcommand,
+	}
+	if err := templateFiles(promiseTemplates, outputDir, templates, templateValues); err != nil {
+		return err
 	}
 
 	dirName := "current"

--- a/cmd/templates/workflows/Dockerfile.tpl
+++ b/cmd/templates/workflows/Dockerfile.tpl
@@ -1,0 +1,11 @@
+FROM "alpine"
+
+RUN apk update && apk add --no-cache yq
+
+ADD scripts/pipeline.sh /usr/bin/pipeline.sh
+ADD resources resources
+
+RUN chmod +x /usr/bin/pipeline.sh
+
+CMD [ "sh", "-c", "pipeline.sh" ]
+ENTRYPOINT []

--- a/cmd/templates/workflows/pipeline.sh.tpl
+++ b/cmd/templates/workflows/pipeline.sh.tpl
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+set -xe
+
+name="$(yq eval '.metadata.name' /kratix/input/object.yaml)"
+namespace=$(yq '.metadata.namespace' /kratix/input/object.yaml)
+
+echo "Hello from ${name} ${namespace}"


### PR DESCRIPTION
this pr includes three commits:

- **feat: add container to include Dockerfile**
    - the command currently adds the Dockerfile and a script, but the Dockerfile
      was empty.
    - also: instead of generating file with contents by hand, i moved the
      contents to a template file.
- **fix: move templating logic to root.go**
    - small chore to concentrate the templating logic in one place; there's
      probably other places that i can update to use the new function, but kept
      it simple for now
