### PR TITLE
feat: allow deps to be added as workflows

### DIFF
--- a/cmd/add_container.go
+++ b/cmd/add_container.go
@@ -63,7 +63,8 @@ func AddContainer(cmd *cobra.Command, args []string) error {
 	}
 
 	pipelineScriptFilename := "pipeline.sh"
-	fmt.Printf("Customise your container by editing the workflows/%s/%s/%s/%s/scripts/%s \n", workflow, action, pipelineName, containerName, pipelineScriptFilename)
+    scriptsPath := filepath.Join("workflows", workflow, action, pipelineName, containerName, "scripts", pipelineScriptFilename)
+	fmt.Printf("Customise your container by editing %s \n", scriptsPath)
 	fmt.Println("Don't forget to build and push your image!")
 	return nil
 }

--- a/cmd/add_container.go
+++ b/cmd/add_container.go
@@ -58,18 +58,18 @@ func AddContainer(cmd *cobra.Command, args []string) error {
 	pipelineParts := strings.Split(pipelineInput, "/")
 	workflow, action, pipelineName := pipelineParts[0], pipelineParts[1], pipelineParts[2]
 
-	if err := generateWorkflow(workflow, action, pipelineName, false); err != nil {
+	if err := generateWorkflow(workflow, action, pipelineName, containerName, image, false); err != nil {
 		return err
 	}
 
 	pipelineScriptFilename := "pipeline.sh"
-    scriptsPath := filepath.Join("workflows", workflow, action, pipelineName, containerName, "scripts", pipelineScriptFilename)
+	scriptsPath := filepath.Join("workflows", workflow, action, pipelineName, containerName, "scripts", pipelineScriptFilename)
 	fmt.Printf("Customise your container by editing %s \n", scriptsPath)
 	fmt.Println("Don't forget to build and push your image!")
 	return nil
 }
 
-func generateWorkflow(workflow string, action string, pipelineName string, overwrite bool) error {
+func generateWorkflow(workflow, action, pipelineName, containerName, image string, overwrite bool) error {
 	container = v1alpha1.Container{
 		Name:  containerName,
 		Image: image,

--- a/cmd/update_dependencies.go
+++ b/cmd/update_dependencies.go
@@ -23,44 +23,43 @@ Kratix update dependencies local-dir/ `,
 	RunE: updateDependencies,
 }
 
+var depsAsWorkflow bool
+
 func init() {
 	updateCmd.AddCommand(updateDependenciesCmd)
 	updateDependenciesCmd.Flags().StringVarP(&dir, "dir", "d", ".", "Directory to read Promise from")
+	updateDependenciesCmd.Flags().BoolVar(&depsAsWorkflow, "as-workflow", false, "Whether to include dependencies as a workflow or not; default is false")
+	updateDependenciesCmd.Flags().StringVarP(&image, "image", "i", "", "The image used by this container.")
 }
 
 func updateDependencies(cmd *cobra.Command, args []string) error {
 	dependenciesDir := args[0]
-	dependencies, err := buildDependencies(dependenciesDir)
+	if depsAsWorkflow {
+		return addDepsAsWorkflow(dependenciesDir)
+	}
+
+	var depBytes []byte
+	var dependencies []v1alpha1.Dependency
+	file := dependencyFile()
+	dependencies, err = buildDependencies(dependenciesDir)
 	if err != nil {
 		return err
 	}
 
-	var depBytes []byte
 	if depBytes, err = yamlsig.Marshal(dependencies); err != nil {
 		return err
 	}
 
-	var bytes []byte
-	file := dependencyFile()
 	switch file {
 	case dependenciesFileName:
-		bytes = depBytes
+		err = os.WriteFile(filepath.Join(dir, dependenciesFileName), depBytes, filePerm)
 	case promiseFileName:
-		var promise v1alpha1.Promise
-		if promise, err = getPromise(filepath.Join(dir, "promise.yaml")); err != nil {
-			return err
-		}
-		promise.Spec.Dependencies = dependencies
-		bytes, err = yamlsig.Marshal(promise)
-		if err != nil {
-			return err
-		}
+		err = updatePromiseDependencies(dependencies)
 	}
 
-	if err = os.WriteFile(filepath.Join(dir, file), bytes, filePerm); err != nil {
+	if err != nil {
 		return err
 	}
-
 	fmt.Printf("Updated %s\n", file)
 	return nil
 }
@@ -139,4 +138,81 @@ func getPromise(filePath string) (v1alpha1.Promise, error) {
 		return v1alpha1.Promise{}, err
 	}
 	return promise, nil
+}
+
+func updatePromiseDependencies(dependencies []v1alpha1.Dependency) error {
+	var promise v1alpha1.Promise
+	if promise, err = getPromise(filepath.Join(dir, "promise.yaml")); err != nil {
+		return err
+	}
+	promise.Spec.Dependencies = dependencies
+	bytes, err := yamlsig.Marshal(promise)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(dir, promiseFileName), bytes, filePerm)
+}
+
+func addDepsAsWorkflow(dependenciesDir string) error {
+	containerName = "configure-deps"
+	if image == "" {
+		return fmt.Errorf("--image is required when --as-workflow is set")
+	}
+	err := generateWorkflow("promise", "configure", "dependencies", true)
+	if err != nil {
+		return err
+	}
+
+	workflowDir := filepath.Join(dir, "workflows/promise/configure/dependencies", containerName)
+	resourcesDir := filepath.Join(workflowDir, "resources")
+	scriptsDir := filepath.Join(workflowDir, "scripts")
+	if err := copyFiles(dependenciesDir, resourcesDir); err != nil {
+		return err
+	}
+
+	pipelineScriptContent := "#!/usr/bin/env sh\n\ncp /resources/* /kratix/output"
+	if err := os.WriteFile(filepath.Join(scriptsDir, "pipeline.sh"), []byte(pipelineScriptContent), filePerm); err != nil {
+		return err
+	}
+
+	file := dependencyFile()
+	switch file {
+	case dependenciesFileName:
+		err = os.Remove(filepath.Join(dir, dependenciesFileName))
+	case promiseFileName:
+		err = updatePromiseDependencies([]v1alpha1.Dependency{})
+	}
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("Dependencies added as a Promise workflow.")
+	fmt.Println("Don't forget to build and push the image.")
+	return nil
+}
+
+func copyFiles(src, dest string) error {
+	files, err := os.ReadDir(src)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range files {
+		if f.IsDir() {
+			if err := os.Mkdir(filepath.Join(dest, f.Name()), 0755); err != nil {
+				return err
+			}
+			if err := copyFiles(filepath.Join(src, f.Name()), filepath.Join(dest, f.Name())); err != nil {
+				return err
+			}
+		}
+		fileContents, err := os.ReadFile(filepath.Join(src, f.Name()))
+		if err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(dest, f.Name()), fileContents, 0644); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/test/add_test.go
+++ b/test/add_test.go
@@ -103,7 +103,7 @@ var _ = Describe("add", func() {
 				Expect(pipelines[v1alpha1.WorkflowTypePromise][v1alpha1.WorkflowActionDelete][0].Spec.Containers[0].Image).To(Equal("project/cleanup:latest"))
 				Expect(pipelines[v1alpha1.WorkflowTypePromise][v1alpha1.WorkflowActionDelete][0].Spec.Containers[0].Name).To(Equal("project-cleanup"))
 
-				Expect(sess.Out).To(gbytes.Say("Customise your container by editing the workflows/promise/configure/pipeline0/image/scripts/pipeline.sh"))
+				Expect(sess.Out).To(gbytes.Say("Customise your container by editing workflows/promise/configure/pipeline0/image/scripts/pipeline.sh"))
 				script := getPipelineScript(dir, "promise", "configure", "pipeline1", "a-good-container")
 				Expect(script).To(ContainSubstring("Hello from ${name} ${namespace}"))
 				Expect(sess.Out).To(gbytes.Say("Don't forget to build and push your image!"))
@@ -216,7 +216,7 @@ var _ = Describe("add", func() {
 					Expect(pipelines[0].Spec.Containers[1].Name).To(Equal("superb-image"))
 					Expect(pipelines[0].Spec.Containers[1].Image).To(Equal("image:latest"))
 
-					Expect(sess.Out).To(gbytes.Say("Customise your container by editing the workflows/promise/configure/pipeline0/image/scripts/pipeline.sh"))
+					Expect(sess.Out).To(gbytes.Say("Customise your container by editing workflows/promise/configure/pipeline0/image/scripts/pipeline.sh"))
 					Expect(sess.Out).To(gbytes.Say("Don't forget to build and push your image!"))
 
 					Expect(getPipelineScript(dir, "promise", "configure", "pipeline0", "image")).To(ContainSubstring("Hello from ${name} ${namespace}"))


### PR DESCRIPTION
this commit introduces a new flag to the `update dependencies` command:
`--as-workflow`.

when set, the dependencies will be added to the promise as a workflow, instead
of copying them all to the promise `spec.dependencies` field.

updating dependencies with `--as-workflow` requires `--image` to be set as well.

if there's a `dependencies.yaml` file in the working directory, it will be
removed; if there's a `promise.yaml` file, the contents of `spec.dependencies`
will be wiped out -- we can change this behavior if needed.
