### PR TITLE
feat: do not include dependencies in init-operator

### DIFF
--- a/cmd/init_operator_promise.go
+++ b/cmd/init_operator_promise.go
@@ -101,6 +101,9 @@ func InitPromiseFromOperator(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	fmt.Println("Promise from Operator generated successfully.")
+	fmt.Printf("Run 'kratix update dependencies %s' to include the Operator files as dependencies.\n", operatorManifestsDir)
+
 	return nil
 }
 
@@ -257,7 +260,6 @@ func getFilesToWrite(promiseName string, split bool, workflowDirectory string, d
 
 	if split {
 		return map[string]interface{}{
-			"dependencies.yaml":     dependencies,
 			"api.yaml":              crd,
 			"example-resource.yaml": exampleResource,
 			workflowDirectory: map[string]interface{}{
@@ -267,7 +269,7 @@ func getFilesToWrite(promiseName string, split bool, workflowDirectory string, d
 		}, nil
 	}
 
-	promise, err := generatePromise(promiseName, dependencies, crd, workflow)
+	promise, err := generatePromise(promiseName, nil, crd, workflow)
 	if err != nil {
 		return nil, err
 	}

--- a/test/init_operator_promise_test.go
+++ b/test/init_operator_promise_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/onsi/gomega/gexec"
+
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -58,11 +60,15 @@ var _ = Describe("InitOperatorPromise", func() {
 		})
 	})
 
-	Describe("generating a promise from an operator", func() {
+	Describe("with --split", func() {
 		Describe("the generated files", func() {
-			var generatedFiles []string
+			var (
+				generatedFiles []string
+				session        *gexec.Session
+			)
+
 			BeforeEach(func() {
-				r.run(initPromiseCmd...)
+				session = r.run(initPromiseCmd...)
 				fileEntries, err := os.ReadDir(workingDir)
 				generatedFiles = []string{}
 				for _, fileEntry := range fileEntries {
@@ -71,14 +77,8 @@ var _ = Describe("InitOperatorPromise", func() {
 				Expect(err).ToNot(HaveOccurred())
 			})
 
-			It("includes a dependencies.yaml file with the contents of the operator manifests", func() {
-				Expect(generatedFiles).To(ContainElement("dependencies.yaml"))
-
-				var dependencies v1alpha1.Dependencies
-				depsContent, err := os.ReadFile(filepath.Join(workingDir, "dependencies.yaml"))
-				Expect(err).ToNot(HaveOccurred())
-				Expect(yaml.Unmarshal(depsContent, &dependencies)).To(Succeed())
-				expectDependenciesToMatchOperatorManifests(dependencies)
+			It("does not include a dependencies.yaml", func() {
+				Expect(generatedFiles).ToNot(ContainElement("dependencies.yaml"))
 			})
 
 			It("includes an api.yaml file with the api-from CRD", func() {
@@ -116,6 +116,13 @@ var _ = Describe("InitOperatorPromise", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(readmeContents).To(ContainSubstring("init operator-promise postgresql --group myorg.com --kind database"))
 			})
+
+			It("outputs a message", func() {
+				Expect(session.Out).To(SatisfyAll(
+					gbytes.Say("Promise from Operator generated successfully."),
+					gbytes.Say("Run 'kratix update dependencies %s' to include the Operator files as dependencies.", r.flags["--operator-manifests"]),
+				))
+			})
 		})
 
 		When("a version is provided", func() {
@@ -151,10 +158,11 @@ var _ = Describe("InitOperatorPromise", func() {
 		})
 	})
 
-	Describe("when the --split flag is not provided", func() {
+	Describe("no --split", func() {
+		var session *gexec.Session
 		BeforeEach(func() {
 			delete(r.flags, "--split")
-			r.run(initPromiseCmd...)
+			session = r.run(initPromiseCmd...)
 		})
 
 		It("generates a single promise.yaml", func() {
@@ -183,8 +191,8 @@ var _ = Describe("InitOperatorPromise", func() {
 				expectCRDToMatchOperatorCRD(*crd)
 			})
 
-			By("setting the promise dependencies", func() {
-				expectDependenciesToMatchOperatorManifests(promise.Spec.Dependencies)
+			By("not setting the promise dependencies", func() {
+				Expect(promise.Spec.Dependencies).To(BeNil())
 			})
 
 			By("setting the promise workflows", func() {
@@ -205,6 +213,13 @@ var _ = Describe("InitOperatorPromise", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(readmeContents).To(ContainSubstring("init operator-promise postgresql --group myorg.com --kind database"))
 		})
+
+		It("outputs a message", func() {
+			Expect(session.Out).To(SatisfyAll(
+				gbytes.Say("Promise from Operator generated successfully."),
+				gbytes.Say("Run 'kratix update dependencies %s' to include the Operator files as dependencies.", r.flags["--operator-manifests"]),
+			))
+		})
 	})
 
 	Describe("end-to-end Promise generation", func() {
@@ -216,6 +231,9 @@ var _ = Describe("InitOperatorPromise", func() {
 			delete(r.flags, "--split")
 
 			r.run(initPromiseCmd...)
+
+			r.flags = nil
+			r.run("update", "dependencies", "assets/e2e-cnpg/manifests", "--dir", workingDir)
 		})
 
 		It("generates the expected promise.yaml", func() {


### PR DESCRIPTION
instead, output a message asking the user to run `update dependencies`
to include it;

this allows users to use more easily control what are the dependencies
they want to add to their promise, as well as chose to include them as
workflows.
