### PR TITLE
Better help message for init commands

### DIFF
--- a/cmd/init_helm_promise.go
+++ b/cmd/init_helm_promise.go
@@ -14,14 +14,14 @@ import (
 )
 
 var intHelmPromiseCmd = &cobra.Command{
-	Use:   "helm-promise PROMISE-NAME --chart-url HELM-CHART-URL [--version]",
+	Use:   "helm-promise PROMISE-NAME --chart-url HELM-CHART-URL --group PROMISE-API-GROUP --kind PROMISE-API-KIND [--chart-version]",
 	Short: "Initialize a new Promise from a Helm chart",
 	Long:  "Initialize a new Promise from a Helm Chart",
 	Example: `  # initialize a new promise from an OCI Helm Chart
-  kratix init helm-promise postgresql --chart-url oci://registry-1.docker.io/bitnamicharts/postgresql [--chart-version v1.0.0]
+  kratix init helm-promise postgresql --chart-url oci://registry-1.docker.io/bitnamicharts/postgresql [--chart-version]
 
   # initialize a new promise from a Helm Chart repository
-  kratix init helm-promise postgresql --chart-url https://fluxcd-community.github.io/helm-charts --chart-name flux2 [--chart-version v1.0.0]
+  kratix init helm-promise postgresql --chart-url https://fluxcd-community.github.io/helm-charts --chart-name flux2 [--chart-version]
 
   # initialize a new promise from a Helm Chart tar URL
   kratix init helm-promise postgresql --chart-url https://github.com/stefanprodan/podinfo/raw/gh-pages/podinfo-0.2.1.tgz

--- a/cmd/init_operator_promise.go
+++ b/cmd/init_operator_promise.go
@@ -19,7 +19,7 @@ import (
 )
 
 var operatorPromiseCmd = &cobra.Command{
-	Use:   "operator-promise PROMISE-NAME --group API-GROUP --version API-VERSION --kind API-KIND --operator-manifests OPERATOR-MANIFESTS-DIR --api-schema-from CRD-NAME",
+	Use:   "operator-promise PROMISE-NAME --group PROMISE-API-GROUP --version PROMISE-API-VERSION --kind PROMISE-API-KIND --operator-manifests OPERATOR-MANIFESTS-DIR --api-schema-from CRD-NAME",
 	Short: "Generate a Promise from a given Kubernetes Operator.",
 	Long:  `Generate a Promise from a given Kubernetes Operator.`,
 	Args:  cobra.ExactArgs(1),

--- a/cmd/init_promise.go
+++ b/cmd/init_promise.go
@@ -12,7 +12,7 @@ import (
 var promiseTemplates embed.FS
 
 var initPromiseCmd = &cobra.Command{
-	Use:   "promise PROMISE-NAME --group API-GROUP --kind API-KIND",
+	Use:   "promise PROMISE-NAME --group PROMISE-API-GROUP --kind PROMISE-API-KIND",
 	Short: "Initialize a new Promise",
 	Long:  `Initialize a new Promise within the current directory, with all the necessary files to get started`,
 	Example: `  # initialize a new promise with the api group and provided kind


### PR DESCRIPTION
closes #31

- showing required GVK flags in help for `kratix init helm-promise`

```
❯ ./bin/kratix init helm-promise
Error: accepts 1 arg(s), received 0
Usage:
  kratix init helm-promise PROMISE-NAME --chart-url HELM-CHART-URL --group PROMISE-API-GROUP --kind PROMISE-API-KIND [--chart-version] [flags]

❯ ./bin/kratix init operator-promise
Error: accepts 1 arg(s), received 0
Usage:
  kratix init operator-promise PROMISE-NAME --group PROMISE-API-GROUP --version PROMISE-API-VERSION --kind PROMISE-API-KIND --operator-manifests OPERATOR-MANIFESTS-DIR --api-schema-from CRD-NAME [flags]

❯ ./bin/kratix init promise
Error: accepts 1 arg(s), received 0
Usage:
  kratix init promise PROMISE-NAME --group PROMISE-API-GROUP --kind PROMISE-API-KIND [flags]
```