### PR TITLE
fix(#29): better error message for invalid pipeline input

### DIFF
--- a/cmd/add_container.go
+++ b/cmd/add_container.go
@@ -57,6 +57,11 @@ func AddContainer(cmd *cobra.Command, args []string) error {
 
 	pipelineInput := args[0]
 	pipelineParts := strings.Split(pipelineInput, "/")
+
+	if len(pipelineParts) != 3 {
+		return fmt.Errorf("invalid pipeline format: %s, expected format: LIFECYCLE/ACTION/PIPELINE-NAME", pipelineInput)
+	}
+
 	workflow, action, pipelineName := pipelineParts[0], pipelineParts[1], pipelineParts[2]
 
 	if err := generateWorkflow(workflow, action, pipelineName, containerName, image, false); err != nil {

--- a/cmd/add_container.go
+++ b/cmd/add_container.go
@@ -76,6 +76,18 @@ func AddContainer(cmd *cobra.Command, args []string) error {
 }
 
 func generateWorkflow(workflow, action, pipelineName, containerName, image string, overwrite bool) error {
+	if workflow != "promise" && workflow != "resource" {
+		return fmt.Errorf("invalid lifecycle: %s, expected one of: promise, resource", workflow)
+	}
+
+	if action != "configure" && action != "delete" {
+		return fmt.Errorf("invalid action: %s, expected one of: configure, delete", action)
+	}
+
+	if pipelineName == "" {
+		return fmt.Errorf("pipeline name cannot be empty")
+	}
+
 	container = v1alpha1.Container{
 		Name:  containerName,
 		Image: image,

--- a/test/add_test.go
+++ b/test/add_test.go
@@ -63,6 +63,30 @@ var _ = Describe("add", func() {
 			})
 		})
 
+		When("called with an invalid LIFECYCLE", func() {
+			It("fails with message", func() {
+				r.exitCode = 1
+				session := r.run("add", "container", "invalid/delete/instance", "--image", "animage:latest")
+				Expect(session.Err).To(gbytes.Say(`invalid lifecycle: invalid, expected one of: promise, resource`))
+			})
+		})
+
+		When("called with an invalid ACTION", func() {
+			It("fails with message", func() {
+				r.exitCode = 1
+				session := r.run("add", "container", "promise/invalid/instance", "--image", "animage:latest")
+				Expect(session.Err).To(gbytes.Say(`invalid action: invalid, expected one of: configure, delete`))
+			})
+		})
+
+		When("called with an empty PIPELINE-NAME", func() {
+			It("fails with message", func() {
+				r.exitCode = 1
+				session := r.run("add", "container", "promise/configure/", "--image", "animage:latest")
+				Expect(session.Err).To(gbytes.Say(`pipeline name cannot be empty`))
+			})
+		})
+
 		When("called with --help", func() {
 			It("prints the help", func() {
 				session := r.run("add", "container", "--help")

--- a/test/add_test.go
+++ b/test/add_test.go
@@ -55,6 +55,14 @@ var _ = Describe("add", func() {
 			})
 		})
 
+		When("called without 3 parts to the pipeline input", func() {
+			It("fails with message", func() {
+				r.exitCode = 1
+				session := r.run("add", "container", "promise/delete", "--image", "animage:latest")
+				Expect(session.Err).To(gbytes.Say(`invalid pipeline format: promise/delete, expected format: LIFECYCLE/ACTION/PIPELINE-NAME`))
+			})
+		})
+
 		When("called with --help", func() {
 			It("prints the help", func() {
 				session := r.run("add", "container", "--help")


### PR DESCRIPTION
Small fix to make the error message clearer when the `LIFECYCLE/ACTION/PIPELINE-NAME` format is not followed.

fixes #29 