### PR TITLE
Fix build promise for helm and operator

### DIFF
--- a/cmd/add_container.go
+++ b/cmd/add_container.go
@@ -74,8 +74,6 @@ func AddContainer(cmd *cobra.Command, args []string) error {
 }
 
 func generateWorkflow(lifecycle, action, pipelineName, containerName, image string, overwrite bool) error {
-	var err error
-
 	if lifecycle != "promise" && lifecycle != "resource" {
 		return fmt.Errorf("invalid lifecycle: %s, expected one of: promise, resource", lifecycle)
 	}
@@ -108,6 +106,7 @@ func generateWorkflow(lifecycle, action, pipelineName, containerName, image stri
 	var pipelines []v1alpha1.Pipeline
 	var pipelineIdx = -1
 	var fileBytes []byte
+	var err error
 	if splitFiles && workflowFileFound(filePath) {
 		fileBytes, err = os.ReadFile(filePath)
 		if err != nil {
@@ -137,7 +136,7 @@ func generateWorkflow(lifecycle, action, pipelineName, containerName, image stri
 			return err
 		}
 
-		pipelines, pipelineIdx, err = findPipelinesForWorkflowAction(lifecycle, action, pipelineName, allPipelines)
+		pipelines, pipelineIdx, err = findPipelinesForLifecycleAction(lifecycle, action, pipelineName, allPipelines)
 		if err != nil {
 			return err
 		}
@@ -210,7 +209,7 @@ func generateContainerName(image string) string {
 	return strings.Split(nameAndVersion, ":")[0]
 }
 
-func findPipelinesForWorkflowAction(lifecycle, action, pipelineName string, allPipelines map[v1alpha1.Type]map[v1alpha1.Action][]v1alpha1.Pipeline) ([]v1alpha1.Pipeline, int, error) {
+func findPipelinesForLifecycleAction(lifecycle, action, pipelineName string, allPipelines map[v1alpha1.Type]map[v1alpha1.Action][]v1alpha1.Pipeline) ([]v1alpha1.Pipeline, int, error) {
 	var pipelines []v1alpha1.Pipeline
 	switch lifecycle {
 	case "promise":

--- a/cmd/add_container.go
+++ b/cmd/add_container.go
@@ -38,8 +38,6 @@ var addContainerCmd = &cobra.Command{
 var (
 	image, containerName string
 	container            v1alpha1.Container
-	pipelineIndex        = -1
-	workflowTrigger      v1alpha1.Workflows
 )
 
 func init() {
@@ -76,6 +74,8 @@ func AddContainer(cmd *cobra.Command, args []string) error {
 }
 
 func generateWorkflow(lifecycle, action, pipelineName, containerName, image string, overwrite bool) error {
+	var err error
+
 	if lifecycle != "promise" && lifecycle != "resource" {
 		return fmt.Errorf("invalid lifecycle: %s, expected one of: promise, resource", lifecycle)
 	}
@@ -88,34 +88,34 @@ func generateWorkflow(lifecycle, action, pipelineName, containerName, image stri
 		return fmt.Errorf("pipeline name cannot be empty")
 	}
 
-	container = v1alpha1.Container{
+	container := v1alpha1.Container{
 		Name:  containerName,
 		Image: image,
 	}
 
-	var workflowPath = filepath.Join("workflows", lifecycle, action)
-	var filePath string
-	var fileBytes []byte
+	workflowPath := filepath.Join("workflows", lifecycle, action)
 	var promise v1alpha1.Promise
 
 	splitFiles := filesGeneratedWithSplit(dir)
 
-	var pipelines []v1alpha1.Pipeline
+	var filePath string
 	if splitFiles {
 		filePath = filepath.Join(dir, workflowPath, "workflow.yaml")
 	} else {
 		filePath = filepath.Join(dir, "promise.yaml")
 	}
 
-	var err error
+	var pipelines []v1alpha1.Pipeline
+	var pipelineIdx = -1
+	var fileBytes []byte
 	if splitFiles && workflowFileFound(filePath) {
 		fileBytes, err = os.ReadFile(filePath)
 		if err != nil {
 			return err
 		}
-		yaml.Unmarshal(fileBytes, &workflowTrigger)
+		yaml.Unmarshal(fileBytes, &pipelines)
 
-		pipelines, pipelineIndex, err = getPipelinesFromWorkflowYaml(workflowTrigger, workflow, action, pipelineName)
+		pipelineIdx, err = getPipelineIdx(pipelines, pipelineName)
 		if err != nil {
 			return err
 		}
@@ -137,22 +137,22 @@ func generateWorkflow(lifecycle, action, pipelineName, containerName, image stri
 			return err
 		}
 
-		pipelines, pipelineIndex, err = findPipelinesForWorkflowAction(lifecycle, action, pipelineName, allPipelines)
+		pipelines, pipelineIdx, err = findPipelinesForWorkflowAction(lifecycle, action, pipelineName, allPipelines)
 		if err != nil {
 			return err
 		}
 	}
 
 	var pipelinesUnstructured []unstructured.Unstructured
-	if pipelineIndex != -1 {
-		containerIdx := containerIndex(pipelines[pipelineIndex], container.Name)
+	if pipelineIdx != -1 {
+		containerIdx := getContainerIdx(pipelines[pipelineIdx], container.Name)
 		if containerIdx == -1 {
-			pipelines[pipelineIndex].Spec.Containers = append(pipelines[pipelineIndex].Spec.Containers, container)
+			pipelines[pipelineIdx].Spec.Containers = append(pipelines[pipelineIdx].Spec.Containers, container)
 		} else {
 			if !overwrite {
-				return fmt.Errorf("image '%s' already exists in Pipeline", container.Name)
+				return fmt.Errorf("image '%s' already exists in Pipeline '%s'", container.Name, pipelineName)
 			}
-			pipelines[pipelineIndex].Spec.Containers[containerIdx] = container
+			pipelines[pipelineIdx].Spec.Containers[containerIdx] = container
 		}
 
 		pipelinesUnstructured, err = pipelinesToUnstructured(pipelines)
@@ -181,8 +181,7 @@ func generateWorkflow(lifecycle, action, pipelineName, containerName, image stri
 	}
 
 	if splitFiles {
-		updateWorkflow(workflow, action, pipelinesUnstructured, &workflowTrigger)
-		fileBytes, err = yaml.Marshal(workflowTrigger)
+		fileBytes, err = yaml.Marshal(pipelinesUnstructured)
 		if err != nil {
 			return err
 		}
@@ -220,8 +219,6 @@ func findPipelinesForWorkflowAction(lifecycle, action, pipelineName string, allP
 			pipelines = allPipelines[v1alpha1.WorkflowTypePromise][v1alpha1.WorkflowActionConfigure]
 		case "delete":
 			pipelines = allPipelines[v1alpha1.WorkflowTypePromise][v1alpha1.WorkflowActionDelete]
-		default:
-			return nil, -1, fmt.Errorf("invalid action: %s", action)
 		}
 	case "resource":
 		switch action {
@@ -229,19 +226,15 @@ func findPipelinesForWorkflowAction(lifecycle, action, pipelineName string, allP
 			pipelines = allPipelines[v1alpha1.WorkflowTypeResource][v1alpha1.WorkflowActionConfigure]
 		case "delete":
 			pipelines = allPipelines[v1alpha1.WorkflowTypeResource][v1alpha1.WorkflowActionDelete]
-		default:
-			return nil, -1, fmt.Errorf("invalid action: %s", action)
 		}
-	default:
-		return nil, -1, fmt.Errorf("invalid lifecycle: %s", lifecycle)
 	}
 
-	for i, p := range pipelines {
-		if p.Name == pipelineName {
-			return pipelines, i, nil
-		}
+	idx, err := getPipelineIdx(pipelines, pipelineName)
+	if err != nil {
+		return nil, -1, err
 	}
-	return pipelines, -1, nil
+
+	return pipelines, idx, nil
 }
 
 func updatePipeline(lifecycle, action string, pipelines []unstructured.Unstructured, promise *v1alpha1.Promise) {
@@ -316,62 +309,17 @@ func workflowFileFound(workflowFilePath string) bool {
 	return true
 }
 
-func getPipelinesFromWorkflowYaml(workflow v1alpha1.Workflows, lifecycle string, action string, pipelineName string) (pipelines []v1alpha1.Pipeline, index int, err error) {
-	var unstructuredWorkflowPipelines []unstructured.Unstructured
-	switch lifecycle {
-	case "promise":
-		switch action {
-		case "configure":
-			unstructuredWorkflowPipelines = workflow.Promise.Configure
-		case "delete":
-			unstructuredWorkflowPipelines = workflow.Promise.Delete
-		}
-	case "resource":
-		switch action {
-		case "configure":
-			unstructuredWorkflowPipelines = workflow.Resource.Configure
-		case "delete":
-			unstructuredWorkflowPipelines = workflow.Resource.Delete
-		}
-	}
-
-	for index, p := range unstructuredWorkflowPipelines {
+func getPipelineIdx(pipelines []v1alpha1.Pipeline, pipelineName string) (int, error) {
+	for idx, p := range pipelines {
 		if p.GetName() == pipelineName {
-			workflowPipelines, err := v1alpha1.PipelinesFromUnstructured(unstructuredWorkflowPipelines, ctrl.LoggerFrom(context.Background()))
-			if err != nil {
-				return []v1alpha1.Pipeline{}, index, err
-			}
-			return workflowPipelines, index, nil
+			return idx, nil
 		}
 	}
 
-	workflowPipelines, err := v1alpha1.PipelinesFromUnstructured(unstructuredWorkflowPipelines, ctrl.LoggerFrom(context.Background()))
-	if err != nil {
-		return []v1alpha1.Pipeline{}, index, err
-	}
-	return workflowPipelines, -1, nil
+	return -1, nil
 }
 
-func updateWorkflow(workflow, action string, pipelines []unstructured.Unstructured, workflowTrigger *v1alpha1.Workflows) {
-	switch workflow {
-	case "promise":
-		switch action {
-		case "configure":
-			workflowTrigger.Promise.Configure = pipelines
-		case "delete":
-			workflowTrigger.Promise.Delete = pipelines
-		}
-	case "resource":
-		switch action {
-		case "configure":
-			workflowTrigger.Resource.Configure = pipelines
-		case "delete":
-			workflowTrigger.Resource.Delete = pipelines
-		}
-	}
-}
-
-func containerIndex(pipeline v1alpha1.Pipeline, containerName string) int {
+func getContainerIdx(pipeline v1alpha1.Pipeline, containerName string) int {
 	for i, container := range pipeline.Spec.Containers {
 		if container.Name == containerName {
 			return i

--- a/cmd/init_helm_promise.go
+++ b/cmd/init_helm_promise.go
@@ -72,12 +72,12 @@ func InitHelmPromise(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	dirName := "current"
+	dirName := "the current directory"
 	if outputDir != "." {
 		dirName = outputDir
 	}
 
-	fmt.Printf("%s promise bootstrapped in the %s directory\n", promiseName, dirName)
+	fmt.Printf("%s promise bootstrapped in %s\n", promiseName, dirName)
 	return nil
 }
 

--- a/test/add_test.go
+++ b/test/add_test.go
@@ -232,14 +232,7 @@ var _ = Describe("add", func() {
 					_, err := os.Stat(filepath.Join(dir, "workflows", "promise", "configure", "workflow.yaml"))
 					Expect(err).ToNot(HaveOccurred())
 
-					workflow := getWorkflowsFromSplitFile(dir, "promise", "configure")
-					Expect(workflow.Resource.Configure).To(HaveLen(0))
-					Expect(workflow.Resource.Delete).To(HaveLen(0))
-					Expect(workflow.Promise.Delete).To(HaveLen(0))
-					Expect(workflow.Promise.Configure).To(HaveLen(1))
-
-					pipelines, err := v1alpha1.PipelinesFromUnstructured(workflow.Promise.Configure, ctrl.LoggerFrom(context.Background()))
-					Expect(err).ToNot(HaveOccurred())
+					pipelines := getWorkflowsFromSplitFile(dir, "promise", "configure")
 
 					Expect(pipelines[0].Name).To(Equal("pipeline0"))
 					Expect(pipelines[0].Spec.Containers).To(HaveLen(2))
@@ -277,11 +270,11 @@ func getWorkflows(dir string) map[v1alpha1.Type]map[v1alpha1.Action][]v1alpha1.P
 	return pipelines
 }
 
-func getWorkflowsFromSplitFile(dir, workflowName, action string) v1alpha1.Workflows {
+func getWorkflowsFromSplitFile(dir, workflowName, action string) []v1alpha1.Pipeline {
 	workflowYAML, err := os.ReadFile(filepath.Join(dir, "workflows", workflowName, action, "workflow.yaml"))
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
 
-	var workflows v1alpha1.Workflows
+	var workflows []v1alpha1.Pipeline
 	ExpectWithOffset(1, yaml.Unmarshal(workflowYAML, &workflows)).To(Succeed())
 
 	return workflows

--- a/test/init_operator_promise_test.go
+++ b/test/init_operator_promise_test.go
@@ -302,7 +302,6 @@ func expectDependenciesToMatchOperatorManifests(dependencies v1alpha1.Dependenci
 		"default",
 		"default",
 	))
-
 }
 
 func expectPipelinesToMatchOperatorPipelines(pipelines []v1alpha1.Pipeline) {


### PR DESCRIPTION
This PR fixes the `build promise` command for `init operator-promise` and `init helm-promise`.

The structure of `workflow.yaml` was an array of Pipelines for those commands, but `build promise` expected all of the workflows to be present.

The `build promise` and `add container` code has been changed to read/write an array of Pipelines so that all of the commands are consistent.

fixes #28 