### PR TITLE
fix: (#37) handle null value in helm values files

### DIFF
--- a/internal/helm_values_schema.go
+++ b/internal/helm_values_schema.go
@@ -73,6 +73,12 @@ func getJSONSchema(value interface{}) (*apiextensionsv1.JSONSchemaProps, error) 
 				Schema: schemaV,
 			},
 		}, nil
+	case nil:
+		return &apiextensionsv1.JSONSchemaProps{
+			Type:                   "object",
+			Properties:             map[string]apiextensionsv1.JSONSchemaProps{},
+			XPreserveUnknownFields: pointer.Bool(true),
+		}, nil
 	default:
 		return nil, fmt.Errorf("unsupported type %T found in helm chart values for %v", value, value)
 	}

--- a/internal/helm_values_schema_test.go
+++ b/internal/helm_values_schema_test.go
@@ -58,4 +58,20 @@ var _ = Describe("HelmValuesToSchema()", func() {
 		Expect(schema.Properties["emptyArr"].Type).To(Equal("array"))
 		Expect(schema.Properties["emptyArr"].Items.Schema.XIntOrString).To(BeTrue())
 	})
+
+	It("handles null object", func() {
+		values := map[string]interface{}{
+			"map":    map[string]interface{}{"test": "yo"},
+			"object": nil,
+		}
+		schema, err := internal.HelmValuesToSchema(values)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(schema.Properties).NotTo(BeNil())
+		Expect(schema.Properties["object"].Type).To(Equal("object"))
+		Expect(*schema.Properties["object"].XPreserveUnknownFields).To(BeTrue())
+		Expect(schema.Properties["object"].Properties).To(BeEmpty())
+		Expect(schema.Properties["map"].Type).To(Equal("object"))
+		Expect(schema.Properties["map"].Properties["test"].Type).To(Equal("string"))
+		Expect(*schema.Properties["map"].XPreserveUnknownFields).To(BeTrue())
+	})
 })


### PR DESCRIPTION
Closes #37 

Null values in helm values file will now to parse to an object with no additional properties. 
Using bitnami vault chart as example, which contains null value for `containerSecurityContext.seLinuxOptions` https://github.com/bitnami/charts/blob/main/bitnami/vault/values.yaml#L222:
```
❯ kratix init helm-promise vault --chart-url oci://registry-1.docker.io/bitnamicharts/vault  --group test.org --kind Test --split
vault promise bootstrapped in the current directory
❯ cat api.yaml
                        containerSecurityContext:
                          properties:
                            allowPrivilegeEscalation:
                              type: boolean
...
                            seLinuxOptions:
                              type: object
                              x-kubernetes-preserve-unknown-fields: true
```