### PR TITLE
fix: can fetch chart from a specific version

### DIFF
--- a/cmd/init_helm_promise.go
+++ b/cmd/init_helm_promise.go
@@ -150,6 +150,10 @@ func valuesFromChart() (map[string]interface{}, error) {
 		install.RepoURL = chartURL
 	}
 
+	if chartVersion != "" {
+		install.ChartPathOptions.Version = chartVersion
+	}
+
 	chart, _, err := client.GetChart(getChartName(), &install.ChartPathOptions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch helm chart: %w", err)


### PR DESCRIPTION
## Context

`chart-version` flag was ignored and not used when fetching helm chart. 
```
❯ kratix init helm-promise vault --chart-url oci://registry-1.docker.io/bitnamicharts/vault  --group test.org --kind Test --split --chart-version 999
vault promise bootstrapped in the current directory
```

With this PR, when version set to an non-existing version:
```
❯ kratix init helm-promise vault --chart-url oci://registry-1.docker.io/bitnamicharts/vault  --group test.org --kind Test --split --chart-version 99999
Error: failed to fetch helm chart: registry-1.docker.io/bitnamicharts/vault:99999: not found
Usage:
  kratix init helm-promise PROMISE-NAME --chart-url HELM-CHART-URL --group PROMISE-API-GROUP --kind PROMISE-API-KIND [--chart-version] [flags]
```