### PR TITLE
Gorelease with release please

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,58 @@
+name: release
+
+on:
+  push:
+    branches:
+      - main
+      - '[0-9]+.[0-9]+.x'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  release-please:
+    permissions:
+      contents: write  # for google-github-actions/release-please-action to create release commit
+      pull-requests: write  # for google-github-actions/release-please-action to create release PR
+    runs-on: ubuntu-latest
+    outputs:
+      releases_created: ${{ steps.release.outputs.releases_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    # Release-please creates a PR that tracks all changes
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+      - uses: google-github-actions/release-please-action@e4dc86ba9405554aeba3c6bb2d169500e7d3b4ee # v4.1.1
+        id: release
+        with:
+          command: manifest
+          token: ${{secrets.RELEASE_CREATOR_TOKEN}}
+          default-branch: main
+
+  goreleaser:
+    if: needs.release-please.outputs.releases_created == 'true'
+    permissions:
+      contents: write
+    needs:
+      - release-please
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
+        with:
+          go-version: '1.22'
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@286f3b13b1b49da4ac219696163fb8c1c93e1200 # v6
+        with:
+          # either 'goreleaser' (default) or 'goreleaser-pro'
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_CREATOR_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bin/
 .idea/
+
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,4 +1,12 @@
 project_name: kratix-cli
+
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+
 builds:
   - env:
       - CGO_ENABLED=0
@@ -6,17 +14,24 @@ builds:
       - linux
       - darwin
     ldflags:
-      - -s -w
       - -X main.version={{.Version}}
 
-nfpms:
-  - maintainer: "kratix@syntasso.io"
-    homepage: https://github.com/syntasso/kratix
-    description: >-
-      A CLI for building Kratix promises
-    license: "Apache-2.0"
-    formats:
-      - deb
-      - rpm
-      - apk
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
 
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^.github"
+      - "^.circleci"
+      - "^test"

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,22 @@
+project_name: kratix-cli
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+
+nfpms:
+  - maintainer: "kratix@syntasso.io"
+    homepage: https://github.com/syntasso/kratix
+    description: >-
+      A CLI for building Kratix promises
+    license: "Apache-2.0"
+    formats:
+      - deb
+      - rpm
+      - apk
+

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,11 +3,12 @@ package cmd
 import (
 	"bytes"
 	"embed"
-	"github.com/Masterminds/sprig/v3"
-	"github.com/spf13/cobra"
 	"os"
 	"path/filepath"
 	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+	"github.com/spf13/cobra"
 )
 
 const filePerm = 0644
@@ -17,13 +18,14 @@ var rootCmd = &cobra.Command{
 	Use:     "kratix",
 	Short:   "A CLI tool for Kratix",
 	Long:    `A CLI tool for Kratix`,
-	Version: "v0.0.1",
+	Version: "",
 	Example: `  # To initialize a new promise
   kratix init promise promise-name --group myorg.com --kind Database
 `,
 }
 
-func Execute() {
+func Execute(version string) {
+	rootCmd.Version = version
 	err := rootCmd.Execute()
 	if err != nil {
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -20,6 +20,9 @@ import (
 	"github.com/syntasso/kratix-cli/cmd"
 )
 
+// set at build time by goreleaser, equal to tag name without the v prefix
+var version = ""
+
 func main() {
-	cmd.Execute()
+	cmd.Execute(version)
 }


### PR DESCRIPTION
I've added the secret `RELEASE_CREATOR_TOKEN` to the github repo already (I believe it has enough permissions as its used for releasing in a different repo). 

Next steps:
- Sanity check the configuration I've added. Its pretty much a copy/paste from https://github.com/k8sgpt-ai/k8sgpt as they use this method with a few minor changes.
- Merge
- See that a release PR gets drafted ([example](https://github.com/k8sgpt-ai/k8sgpt/pull/1202))
- We need a [commit on main](https://stackoverflow.com/questions/75789726/release-please-action-reset-version-numbers) to set what the starting version should be (`v0.1.0`?), defaults to `v1.0.0` otherwise.
- Testing merging the release PR successfully triggers the github action, that a release is created and that goreleaser correctly updates the release with the artifacts and does not override the release notes set by release-please