### PR TITLE
Bug: handle single file dependencies with the --image flag 

### DIFF
--- a/cmd/init_operator_promise.go
+++ b/cmd/init_operator_promise.go
@@ -104,7 +104,7 @@ func InitPromiseFromOperator(cmd *cobra.Command, args []string) error {
 	fmt.Println("Promise generated successfully.")
 	fmt.Println("The Operator documents were added as inline dependencies in the Promise Spec.")
 	fmt.Println("You can move them to a workflow by running:")
-	fmt.Printf("\tkratix update dependencies --image yourorg/your-image:tag\n")
+	fmt.Printf("\tkratix update dependencies %s --image yourorg/your-image:tag\n", operatorManifestsDir)
 	return nil
 }
 

--- a/cmd/init_promise.go
+++ b/cmd/init_promise.go
@@ -56,15 +56,15 @@ func InitPromise(cmd *cobra.Command, args []string) error {
 	templateValues := generateTemplateValues(promiseName, "promise", "", "")
 
 	templates := map[string]string{
-		resourceFileName: "templates/promise/example-resource.yaml.tpl",
+		resourceFileName: fmt.Sprintf("templates/promise/%s.tpl", resourceFileName),
 		"README.md":      "templates/promise/README.md.tpl",
 	}
 
 	if split {
-		templates[apiFileName] = "templates/promise/api.yaml.tpl"
-		templates[dependenciesFileName] = "templates/promise/dependencies.yaml"
+		templates[apiFileName] = fmt.Sprintf("templates/promise/%s.tpl", apiFileName)
+		templates[dependenciesFileName] = fmt.Sprintf("templates/promise/%s", dependenciesFileName)
 	} else {
-		templates[promiseFileName] = "templates/promise/promise.yaml.tpl"
+		templates[promiseFileName] = fmt.Sprintf("templates/promise/%s.tpl", promiseFileName)
 	}
 
 	if err := templateFiles(promiseTemplates, outputDir, templates, templateValues); err != nil {

--- a/cmd/update_dependencies.go
+++ b/cmd/update_dependencies.go
@@ -19,9 +19,10 @@ var updateDependenciesCmd = &cobra.Command{
 	Short: "Commands to update promise dependencies",
 	Long:  "Commands to update promise dependencies, by default dependencies are stored in the Promise spec.dependencies field",
 	Example: `# update promise dependencies with all files in 'local-dir'
-kratix update dependencies local-dir/
-# update promise dependencies with single file 'local-file'
-kratix update dependencies local-file`,
+kratix update dependencies path/to/dir/
+
+# update promise dependencies with single file
+kratix update dependencies path/to/file.yaml`,
 	Args: cobra.ExactArgs(1),
 	RunE: updateDependencies,
 }

--- a/test/build_test.go
+++ b/test/build_test.go
@@ -31,6 +31,8 @@ var _ = Describe("build", func() {
 
 		depDir, err = os.MkdirTemp("", "dep")
 		Expect(err).NotTo(HaveOccurred())
+
+		r = &runner{}
 	})
 
 	AfterEach(func() {
@@ -40,7 +42,6 @@ var _ = Describe("build", func() {
 
 	Describe("build --help", func() {
 		It("includes the available build subcommands", func() {
-			r = &runner{}
 			sess := r.run("build", "--help")
 			output := string(sess.Out.Contents())
 			Expect(output).To(SatisfyAll(
@@ -52,7 +53,6 @@ var _ = Describe("build", func() {
 
 	Context("after init promise", func() {
 		BeforeEach(func() {
-			r = &runner{exitCode: 0}
 			r.run("init", "promise", "postgresql", "--group", "syntasso.io", "--kind", "Database", "--split", "--dir", promiseDir)
 
 			Expect(os.WriteFile(filepath.Join(depDir, "deps.yaml"), slices.Concat(
@@ -218,7 +218,6 @@ var _ = Describe("build", func() {
 
 	Context("after init operator promise with split", func() {
 		BeforeEach(func() {
-			r = &runner{exitCode: 0}
 			r.run("init", "operator-promise", "postgresql", "--group", "syntasso.io", "--kind", "Database", "--split", "--dir", promiseDir, "--operator-manifests", "assets/operator", "--api-schema-from", "postgresqls.acid.zalan.do")
 		})
 
@@ -244,7 +243,6 @@ var _ = Describe("build", func() {
 
 	Context("after init helm promise with split", func() {
 		BeforeEach(func() {
-			r = &runner{exitCode: 0}
 			session := r.run("init", "helm-promise", "postgresql", "--chart-url", "https://helm.github.io/examples", "--dir", promiseDir, "--chart-name", "hello-world", "--group", "syntasso.io", "--kind", "Database", "--split")
 			Expect(session.Out).To(gbytes.Say("postgresql promise bootstrapped in %s", promiseDir))
 		})

--- a/test/init_operator_promise_test.go
+++ b/test/init_operator_promise_test.go
@@ -212,7 +212,7 @@ var _ = Describe("InitOperatorPromise", func() {
 		It("outputs a message", func() {
 			Expect(session.Out).To(SatisfyAll(
 				gbytes.Say(`Promise generated successfully.`),
-				gbytes.Say(`kratix update dependencies --image yourorg/your-image:tag`),
+				gbytes.Say(`kratix update dependencies assets/operator --image yourorg/your-image:tag`),
 			))
 		})
 	})
@@ -251,7 +251,7 @@ var _ = Describe("InitOperatorPromise", func() {
 		It("outputs a message", func() {
 			Expect(session.Out).To(SatisfyAll(
 				gbytes.Say(`Promise generated successfully.`),
-				gbytes.Say(`kratix update dependencies --image yourorg/your-image:tag`),
+				gbytes.Say(`kratix update dependencies assets/e2e-cnpg/manifests --image yourorg/your-image:tag`),
 			))
 		})
 	})

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -63,7 +63,7 @@ func (r *runner) run(args ...string) *gexec.Session {
 
 	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	t := 1 * time.Second
+	t := 2 * time.Second
 	if r.timeout > 0 {
 		t = r.timeout
 	}


### PR DESCRIPTION
Validated with:
```
/Users/abbybangser/dev/syntasso/kratix-cli/bin/kratix init operator-promise cnpg --split \
      --group mygroup.org \
      --kind Pg-database \
      --version v1alpha1 \
      --operator-manifests operator-bundle.yaml \
      --api-schema-from clusters.postgresql.cnpg.io

/Users/abbybangser/dev/syntasso/kratix-cli/bin/kratix update dependencies operator-bundle.yaml --image yourorg/your-image:tag
docker build -t yourorg/your-image:tag workflows/promise/configure/dependencies/configure-deps
```

Resolves #54 