### PR TITLE
feat: inherit labels annotations from resource request in output object manifest in operator promise aspect

### DIFF
--- a/aspects/operator-promise/main.go
+++ b/aspects/operator-promise/main.go
@@ -39,6 +39,8 @@ func main() {
 	outputObject.SetNamespace("default")
 	outputObject.SetKind(operatorKind)
 	outputObject.SetAPIVersion(operatorGroup + "/" + operatorVersion)
+	outputObject.SetLabels(uRequestObj.GetLabels())
+	outputObject.SetAnnotations(uRequestObj.GetAnnotations())
 
 	unstructured.SetNestedField(outputObject.Object, uRequestObj.Object["spec"], "spec")
 

--- a/aspects/operator-promise/test/aspect_test.go
+++ b/aspects/operator-promise/test/aspect_test.go
@@ -12,6 +12,11 @@ import (
 var expectedOutput = `apiVersion: example.com/v1
 kind: Example
 metadata:
+  annotations:
+    image-registry: ghcr.io
+  labels:
+    app.kubernetes.io/name: test-object
+    keyy: value
   name: test-object
   namespace: default
 spec:

--- a/aspects/operator-promise/test/assets/test-object.yaml
+++ b/aspects/operator-promise/test/assets/test-object.yaml
@@ -3,6 +3,11 @@ kind: TestObject
 metadata:
   name: test-object
   namespace: non-default
+  labels:
+    app.kubernetes.io/name: test-object
+    keyy: value
+  annotations:
+    image-registry: ghcr.io
 spec:
   field: value
   nested:


### PR DESCRIPTION
## Context

closes #63

Set outputed object manifest's labels and annotations to resource request labels and annotations.