### PR TITLE
add target namespace to helm aspect

### DIFF
--- a/aspects/helm-promise/pipeline.sh
+++ b/aspects/helm-promise/pipeline.sh
@@ -26,4 +26,8 @@ if [ -n "${CHART_VERSION:-}" ]; then
     arguments="$arguments --version $CHART_VERSION"
 fi
 
+if [ -n "${TARGET_NAMESPACE:-}" ]; then
+    arguments="$arguments --namespace $TARGET_NAMESPACE"
+fi
+
 $HELM_BINARY template $name $arguments --values values.yaml > $KRATIX_OUTPUT/object.yaml

--- a/aspects/helm-promise/pipeline_test.bash
+++ b/aspects/helm-promise/pipeline_test.bash
@@ -12,6 +12,8 @@ function testOCI {
   mkdir -p $KRATIX_INPUT
   mkdir -p $KRATIX_OUTPUT
 
+
+
   cat <<EOF > "${KRATIX_INPUT}/object.yaml"
 metadata:
   name: foo
@@ -24,6 +26,8 @@ EOF
   rm -rf $KRATIX_INPUT
   rm -rf $KRATIX_OUTPUT
 }
+
+
 
 function testRepo {
   echo "  testing helm chart from a repo with a name"
@@ -45,6 +49,30 @@ EOF
   rm -rf $KRATIX_OUTPUT
 }
 
+
+function testOCIwithNamespace {
+  echo "  testing OCI helm chart with namespace"
+  export KRATIX_INPUT=/tmp/testOCI/kratix-input
+  export KRATIX_OUTPUT=/tmp/testOCI/kratix-output
+  export TARGET_NAMESPACE=kratix-worker-system
+  mkdir -p $KRATIX_INPUT
+  mkdir -p $KRATIX_OUTPUT
+
+
+
+  cat <<EOF > "${KRATIX_INPUT}/object.yaml"
+metadata:
+  name: foo
+spec:
+  foo: bar
+EOF
+
+  CHART_URL=oci://registry-1.docker.io/bitnamicharts/redis CHART_VERSION=19.6.1 $ROOT/pipeline.sh 2>&1 | grep "template foo oci://registry-1.docker.io/bitnamicharts/redis --version 19.6.1 --namespace kratix-worker-system --values values.yaml"
+  echo "  testing OCI helm chart with namespace passed"
+  rm -rf $KRATIX_INPUT
+  rm -rf $KRATIX_OUTPUT
+}
+
 function cleanup {
   rm values.yaml 2> /dev/null || true
 }
@@ -54,4 +82,5 @@ trap cleanup EXIT
 echo "running helm promise aspect tests"
 testOCI
 testRepo
+testOCIwithNamespace
 echo "all tests passed"


### PR DESCRIPTION
Hey, 

When using this image in the promise configure pipeline, the output is executed under the `kratix-platform-system` namespace. 

With this change I'd want to be able to set a ENV variable for the templated namespace.  

```
          - image: ghcr.io/syntasso/kratix-cli/helm-resource-configure:v0.1.0
            name: instance-configure
            env:
                - name: CHART_URL
                  value: oci://ghcr.io/cloudflare/origin-ca-issuer-charts/origin-ca-issuer
                - name: TARGET_NAMESPACE
                  value: kratix-worker-system
```
