### PR TITLE
fix: include path to main.go in goreleaseer

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,7 @@ builds:
     ldflags:
       - -X main.version={{.Version}}
     binary: kratix
+    main: ./cmd/kratix/
 
 archives:
   - format: tar.gz


### PR DESCRIPTION
## Context

 By default goreleaser assumes that your main.go is in the root directory.

Failure: 

```
+ VERSION=v0.3.0
+ make release
goreleaser release --auto-snapshot --prepare --clean --config .goreleaser.yaml
...
  • building binaries
    • building                                       binary=dist/kratix-cli_linux_arm64/kratix
    • building                                       binary=dist/kratix-cli_linux_amd64_v1/kratix
    • building                                       binary=dist/kratix-cli_linux_386/kratix
    • building                                       binary=dist/kratix-cli_darwin_amd64_v1/kratix
    • building                                       binary=dist/kratix-cli_darwin_arm64/kratix
  ⨯ release failed after 6s                  error=build for kratix does not contain a main function
  ```
https://app.circleci.com/pipelines/github/syntasso/kratix-cli/218/workflows/f9b95f5d-0ca4-4b5f-b539-53f9538af595/jobs/437

go releaser docs: https://goreleaser.com/errors/no-main/