### PR TITLE
Initialise Promises with a version

### DIFF
--- a/cmd/build_promise.go
+++ b/cmd/build_promise.go
@@ -102,6 +102,9 @@ func newPromise(promiseName string) v1alpha1.Promise {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name: promiseName,
+			Labels: map[string]string{
+				"kratix.io/promise-version": "v0.0.1",
+			},
 		},
 	}
 }

--- a/cmd/templates/promise/api.yaml.tpl
+++ b/cmd/templates/promise/api.yaml.tpl
@@ -16,7 +16,6 @@ spec:
           type: object
           properties:
             spec:
-              type: object
 {{ .CRDSchema | indent 14 }}
       served: true
       storage: true

--- a/cmd/templates/promise/promise.yaml.tpl
+++ b/cmd/templates/promise/promise.yaml.tpl
@@ -2,6 +2,8 @@ apiVersion: platform.kratix.io/v1alpha1
 kind: Promise
 metadata:
   name: {{ .Name }}
+  labels:
+    kratix.io/promise-version: v0.0.1
 spec:
   api:
     apiVersion: apiextensions.k8s.io/v1

--- a/test/assets/crossplane/expected-output-with-compositions/promise.yaml
+++ b/test/assets/crossplane/expected-output-with-compositions/promise.yaml
@@ -2,6 +2,8 @@ apiVersion: platform.kratix.io/v1alpha1
 kind: Promise
 metadata:
   creationTimestamp: null
+  labels:
+    kratix.io/promise-version: v0.0.1
   name: s3buckets
 spec:
   api:

--- a/test/assets/crossplane/expected-output-with-skip-dependencies/promise.yaml
+++ b/test/assets/crossplane/expected-output-with-skip-dependencies/promise.yaml
@@ -2,6 +2,8 @@ apiVersion: platform.kratix.io/v1alpha1
 kind: Promise
 metadata:
   creationTimestamp: null
+  labels:
+    kratix.io/promise-version: v0.0.1
   name: s3buckets
 spec:
   api:

--- a/test/assets/e2e-cnpg/expected-promise.yaml
+++ b/test/assets/e2e-cnpg/expected-promise.yaml
@@ -3,6 +3,8 @@ kind: Promise
 metadata:
   creationTimestamp: null
   name: postgresql
+  labels:
+    kratix.io/promise-version: v0.0.1
 spec:
   api:
     apiVersion: apiextensions.k8s.io/v1

--- a/test/assets/terraform/expected-output-with-split/api.yaml
+++ b/test/assets/terraform/expected-output-with-split/api.yaml
@@ -16,7 +16,6 @@ spec:
           type: object
           properties:
             spec:
-              type: object
               properties:
                 argument:
                   description: Arguments passed to the ENTRYPOINT command, include these only if

--- a/test/assets/terraform/expected-output/promise.yaml
+++ b/test/assets/terraform/expected-output/promise.yaml
@@ -2,6 +2,8 @@ apiVersion: platform.kratix.io/v1alpha1
 kind: Promise
 metadata:
   name: googlecloudrun
+  labels:
+    kratix.io/promise-version: v0.0.1
 spec:
   api:
     apiVersion: apiextensions.k8s.io/v1


### PR DESCRIPTION
This will encourage best practice of versioning Promises.

This PR also includes a small fix for a duplicate key in the API spec.