### PR TITLE
🐛 kratix build panics if folder structure does not match promise description

### DIFF
--- a/cmd/add_container.go
+++ b/cmd/add_container.go
@@ -309,7 +309,7 @@ func getPipelineIdx(pipelines []v1alpha1.Pipeline, pipelineName string) (int, er
 		}
 	}
 
-	return -1, nil
+	return -1, fmt.Errorf("Pipeline not found: %s. Check 'promise.yaml/workflows/metadata/name: <pipeline_name>' and pipeline folder name 'workflows/resource/[configure|]/<pipeline_name>' are in sync.", pipelineName)
 }
 
 func getContainerIdx(pipeline v1alpha1.Pipeline, containerName string) int {


### PR DESCRIPTION
Before the change `kratix build` would panic when the defined pipeline name
in the `promise.yaml` does not match the folder name.

The refactoring provides an error messages to state the assumption and
avoids checking for negative indices in higher order functions
which improves resilience and required less code to being written.