### PR TITLE
fix: support empty openAPIV3Schema in xrd for the init-crossplane command

### DIFF
--- a/cmd/init_crossplane_promise.go
+++ b/cmd/init_crossplane_promise.go
@@ -193,6 +193,9 @@ func generateCRDFromXRD(version *xrdv1.CompositeResourceDefinitionVersion) (*api
 	}
 	crd.Name = fmt.Sprintf("%s.%s", crd.Spec.Names.Plural, group)
 
+	if schema.Properties == nil {
+		schema.Properties = make(map[string]apiextensionsv1.JSONSchemaProps)
+	}
 	specProp := schema.Properties["spec"]
 	if schema.Properties["spec"].Properties == nil {
 		specProp.Properties = make(map[string]apiextensionsv1.JSONSchemaProps)

--- a/test/assets/crossplane/expected-output-with-empty-openAPIV3Schema/README.md
+++ b/test/assets/crossplane/expected-output-with-empty-openAPIV3Schema/README.md
@@ -1,0 +1,28 @@
+|
+  # Promise Template
+
+  This Promise was generated with:
+
+  ```
+  kratix init operator-promise s3buckets --xrd assets/crossplane/xrd-with-empty-openAPIV3Schema.yaml --group syntasso.io --kind S3Bucket
+  ```
+
+  ## Updating API properties
+
+  To update the Promise API, you can use the `kratix update api` command:
+
+  ```
+  kratix update api --property name:string --property region- --kind S3Bucket
+  ```
+
+  ## Updating Workflows
+
+  To add workflow containers, you can use the `kratix add container` command:
+
+  ```
+  kratix add container resource/configure/pipeline0 --image syntasso/postgres-resource:v1.0.0
+  ```
+
+  ## Updating Dependencies
+
+  TBD

--- a/test/assets/crossplane/expected-output-with-empty-openAPIV3Schema/example-resource.yaml
+++ b/test/assets/crossplane/expected-output-with-empty-openAPIV3Schema/example-resource.yaml
@@ -1,0 +1,6 @@
+apiVersion: syntasso.io/v1alpha1
+kind: S3Bucket
+metadata:
+  name: example-request
+  namespace: default
+spec: null

--- a/test/assets/crossplane/expected-output-with-empty-openAPIV3Schema/promise.yaml
+++ b/test/assets/crossplane/expected-output-with-empty-openAPIV3Schema/promise.yaml
@@ -1,0 +1,183 @@
+apiVersion: platform.kratix.io/v1alpha1
+kind: Promise
+metadata:
+  creationTimestamp: null
+  labels:
+    kratix.io/promise-version: v0.0.1
+  name: s3buckets
+spec:
+  api:
+    apiVersion: apiextensions.k8s.io/v1
+    kind: CustomResourceDefinition
+    metadata:
+      creationTimestamp: null
+      name: s3buckets.syntasso.io
+    spec:
+      group: syntasso.io
+      names:
+        kind: S3Bucket
+        plural: s3buckets
+        singular: s3bucket
+      scope: Namespaced
+      versions:
+      - name: v1alpha1
+        schema:
+          openAPIV3Schema:
+            properties:
+              spec:
+                properties:
+                  compositeDeletePolicy:
+                    default: Background
+                    enum:
+                    - Background
+                    - Foreground
+                    type: string
+                  compositionRef:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  compositionRevisionRef:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  compositionRevisionSelector:
+                    properties:
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    required:
+                    - matchLabels
+                    type: object
+                  compositionSelector:
+                    properties:
+                      matchLabels:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    required:
+                    - matchLabels
+                    type: object
+                  compositionUpdatePolicy:
+                    enum:
+                    - Automatic
+                    - Manual
+                    type: string
+                  publishConnectionDetailsTo:
+                    properties:
+                      configRef:
+                        default:
+                          name: default
+                        properties:
+                          name:
+                            type: string
+                        type: object
+                      metadata:
+                        properties:
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          labels:
+                            additionalProperties:
+                              type: string
+                            type: object
+                          type:
+                            type: string
+                        type: object
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  resourceRef:
+                    properties:
+                      apiVersion:
+                        type: string
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    type: object
+                  writeConnectionSecretToRef:
+                    properties:
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+            type: object
+        served: true
+        storage: true
+    status:
+      acceptedNames:
+        kind: ""
+        plural: ""
+      conditions: null
+      storedVersions: null
+  dependencies:
+  - apiVersion: apiextensions.crossplane.io/v1
+    kind: CompositeResourceDefinition
+    metadata:
+      creationTimestamp: null
+      name: xobjectstorages.awsblueprints.io
+    spec:
+      claimNames:
+        kind: ObjectStorage
+        plural: objectstorages
+      connectionSecretKeys:
+      - region
+      - bucket-name
+      - s3-put-policy
+      group: awsblueprints.io
+      names:
+        kind: XObjectStorage
+        plural: xobjectstorages
+      versions:
+      - name: v1alpha1
+        referenceable: true
+        schema:
+          openAPIV3Schema:
+            type: object
+        served: true
+    status:
+      controllers:
+        compositeResourceClaimType:
+          apiVersion: ""
+          kind: ""
+        compositeResourceType:
+          apiVersion: ""
+          kind: ""
+  destinationSelectors:
+  - matchLabels:
+      crossplane: enabled
+  workflows:
+    promise: {}
+    resource:
+      configure:
+      - apiVersion: platform.kratix.io/v1alpha1
+        kind: Pipeline
+        metadata:
+          name: instance-configure
+        spec:
+          containers:
+          - env:
+            - name: XRD_GROUP
+              value: awsblueprints.io
+            - name: XRD_VERSION
+              value: v1alpha1
+            - name: XRD_KIND
+              value: ObjectStorage
+            image: ghcr.io/syntasso/kratix-cli/from-api-to-crossplane-claim:v0.1.0
+            name: from-api-to-crossplane-claim
+status: {}

--- a/test/assets/crossplane/xrd-with-empty-openAPIV3Schema.yaml
+++ b/test/assets/crossplane/xrd-with-empty-openAPIV3Schema.yaml
@@ -1,0 +1,24 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xobjectstorages.awsblueprints.io
+spec:
+  claimNames:
+    kind: ObjectStorage
+    plural: objectstorages
+  group: awsblueprints.io
+  names:
+    kind: XObjectStorage
+    plural: xobjectstorages
+  connectionSecretKeys:
+    - region
+    - bucket-name
+    - s3-put-policy
+  versions:
+    - name: v1alpha1
+      served: true
+      referenceable: true
+      schema:
+        openAPIV3Schema:
+          type: object
+

--- a/test/init_crossplane_promise_test.go
+++ b/test/init_crossplane_promise_test.go
@@ -64,85 +64,30 @@ var _ = Describe("InitCrossplanePromise", func() {
 
 	Describe("generating a promise from an crossplane", func() {
 		var generatedFiles []string
-		Describe("generating a promise with the required flags", func() {
-			When("the XRD file has a spec.properties", func() {
-				BeforeEach(func() {
-					session = r.run(initPromiseCmd...)
-					fileEntries, err := os.ReadDir(workingDir)
-					generatedFiles = []string{}
-					for _, fileEntry := range fileEntries {
-						generatedFiles = append(generatedFiles, fileEntry.Name())
-					}
-					Expect(err).ToNot(HaveOccurred())
-				})
-				It("generates a promise", func() {
-					files := []string{"promise.yaml", "example-resource.yaml", "README.md"}
-					Expect(generatedFiles).To(ConsistOf(files))
-					Expect(cat(filepath.Join(workingDir, "promise.yaml"))).To(Equal(cat("assets/crossplane/expected-output/promise.yaml")))
-					Expect(cat(filepath.Join(workingDir, "example-resource.yaml"))).To(Equal(cat("assets/crossplane/expected-output/example-resource.yaml")))
-					Expect(cat(filepath.Join(workingDir, "README.md"))).To(Equal(cat("assets/crossplane/expected-output/README.md")))
-					Expect(session.Out).To(SatisfyAll(
-						gbytes.Say(`Promise generated successfully.`),
-					))
-				})
-			})
-
-			When("the XRD file have an empty openAPIV3Schema", func() {
-				BeforeEach(func() {
-					r.flags["--xrd"] = "assets/crossplane/xrd-with-empty-openAPIV3Schema.yaml"
-					session = r.run(initPromiseCmd...)
-					fileEntries, err := os.ReadDir(workingDir)
-					generatedFiles = []string{}
-					for _, fileEntry := range fileEntries {
-						generatedFiles = append(generatedFiles, fileEntry.Name())
-					}
-					Expect(err).ToNot(HaveOccurred())
-				})
-				It("generates a promise", func() {
-					files := []string{"promise.yaml", "example-resource.yaml", "README.md"}
-					Expect(generatedFiles).To(ConsistOf(files))
-					Expect(cat(filepath.Join(workingDir, "promise.yaml"))).To(Equal(cat("assets/crossplane/expected-output-with-empty-openAPIV3Schema/promise.yaml")))
-					Expect(cat(filepath.Join(workingDir, "example-resource.yaml"))).To(Equal(cat("assets/crossplane/expected-output-with-empty-openAPIV3Schema/example-resource.yaml")))
-					Expect(cat(filepath.Join(workingDir, "README.md"))).To(Equal(cat("assets/crossplane/expected-output-with-empty-openAPIV3Schema/README.md")))
-					Expect(session.Out).To(SatisfyAll(
-						gbytes.Say(`Promise generated successfully.`),
-					))
-				})
-			})
-			When("the XRD file does not have a spec.properties", func() {
-				BeforeEach(func() {
-					r.flags["--xrd"] = "assets/crossplane/xrd-with-no-spec-properties.yaml"
-					session = r.run(initPromiseCmd...)
-					fileEntries, err := os.ReadDir(workingDir)
-					generatedFiles = []string{}
-					for _, fileEntry := range fileEntries {
-						generatedFiles = append(generatedFiles, fileEntry.Name())
-					}
-					Expect(err).ToNot(HaveOccurred())
-				})
-				It("generates a promise", func() {
-					files := []string{"promise.yaml", "example-resource.yaml", "README.md"}
-					Expect(generatedFiles).To(ConsistOf(files))
-					Expect(cat(filepath.Join(workingDir, "promise.yaml"))).To(Equal(cat("assets/crossplane/expected-output-with-no-spec-properties/promise.yaml")))
-					Expect(cat(filepath.Join(workingDir, "example-resource.yaml"))).To(Equal(cat("assets/crossplane/expected-output-with-no-spec-properties/example-resource.yaml")))
-					Expect(cat(filepath.Join(workingDir, "README.md"))).To(Equal(cat("assets/crossplane/expected-output-with-no-spec-properties/README.md")))
-					Expect(session.Out).To(SatisfyAll(
-						gbytes.Say(`Promise generated successfully.`),
-					))
-				})
-			})
-		})
+		DescribeTable("generating a promise with different XRDs",
+			func(xrdPath, expectedOutputDir string) {
+				if xrdPath != "" {
+					r.flags["--xrd"] = xrdPath
+				}
+				session = r.run(initPromiseCmd...)
+				generatedFiles = getFiles(workingDir)
+				files := []string{"promise.yaml", "example-resource.yaml", "README.md"}
+				Expect(generatedFiles).To(ConsistOf(files))
+				expectFilesEqual(workingDir, expectedOutputDir, files)
+				Expect(session.Out).To(SatisfyAll(
+					gbytes.Say(`Promise generated successfully.`),
+				))
+			},
+			Entry("with spec.properties", "", "assets/crossplane/expected-output"),
+			Entry("with empty openAPIV3Schema", "assets/crossplane/xrd-with-empty-openAPIV3Schema.yaml", "assets/crossplane/expected-output-with-empty-openAPIV3Schema"),
+			Entry("with no spec.properties", "assets/crossplane/xrd-with-no-spec-properties.yaml", "assets/crossplane/expected-output-with-no-spec-properties"),
+		)
 
 		Describe("with the --split flag", func() {
 			BeforeEach(func() {
 				r.flags["--split"] = ""
 				session = r.run(initPromiseCmd...)
-				fileEntries, err := os.ReadDir(workingDir)
-				generatedFiles = []string{}
-				for _, fileEntry := range fileEntries {
-					generatedFiles = append(generatedFiles, fileEntry.Name())
-				}
-				Expect(err).ToNot(HaveOccurred())
+				generatedFiles = getFiles(workingDir)
 			})
 
 			It("generates the expected files", func() {
@@ -163,20 +108,13 @@ var _ = Describe("InitCrossplanePromise", func() {
 			BeforeEach(func() {
 				r.flags["--compositions"] = "assets/crossplane/composition.yaml"
 				session = r.run(initPromiseCmd...)
-				fileEntries, err := os.ReadDir(workingDir)
-				generatedFiles = []string{}
-				for _, fileEntry := range fileEntries {
-					generatedFiles = append(generatedFiles, fileEntry.Name())
-				}
-				Expect(err).ToNot(HaveOccurred())
+				generatedFiles = getFiles(workingDir)
 			})
 
 			It("generates the expected files", func() {
 				files := []string{"promise.yaml", "example-resource.yaml", "README.md"}
 				Expect(generatedFiles).To(ConsistOf(files))
-				Expect(cat(filepath.Join(workingDir, "promise.yaml"))).To(Equal(cat("assets/crossplane/expected-output-with-compositions/promise.yaml")))
-				Expect(cat(filepath.Join(workingDir, "example-resource.yaml"))).To(Equal(cat("assets/crossplane/expected-output-with-compositions/example-resource.yaml")))
-				Expect(cat(filepath.Join(workingDir, "README.md"))).To(Equal(cat("assets/crossplane/expected-output-with-compositions/README.md")))
+				expectFilesEqual(workingDir, "assets/crossplane/expected-output-with-compositions", files)
 				Expect(session.Out).To(SatisfyAll(
 					gbytes.Say(`Promise generated successfully.`),
 				))
@@ -187,20 +125,13 @@ var _ = Describe("InitCrossplanePromise", func() {
 			BeforeEach(func() {
 				r.flags["--skip-dependencies"] = ""
 				session = r.run(initPromiseCmd...)
-				fileEntries, err := os.ReadDir(workingDir)
-				generatedFiles = []string{}
-				for _, fileEntry := range fileEntries {
-					generatedFiles = append(generatedFiles, fileEntry.Name())
-				}
-				Expect(err).ToNot(HaveOccurred())
+				generatedFiles = getFiles(workingDir)
 			})
 
 			It("generates a single promise.yaml", func() {
 				files := []string{"promise.yaml", "example-resource.yaml", "README.md"}
 				Expect(generatedFiles).To(ConsistOf(files))
-				Expect(cat(filepath.Join(workingDir, "promise.yaml"))).To(Equal(cat("assets/crossplane/expected-output-with-skip-dependencies/promise.yaml")))
-				Expect(cat(filepath.Join(workingDir, "example-resource.yaml"))).To(Equal(cat("assets/crossplane/expected-output-with-skip-dependencies/example-resource.yaml")))
-				Expect(cat(filepath.Join(workingDir, "README.md"))).To(Equal(cat("assets/crossplane/expected-output-with-skip-dependencies/README.md")))
+				expectFilesEqual(workingDir, "assets/crossplane/expected-output-with-skip-dependencies", files)
 				Expect(session.Out).To(SatisfyAll(
 					gbytes.Say(`Promise generated successfully.`),
 				))
@@ -208,3 +139,19 @@ var _ = Describe("InitCrossplanePromise", func() {
 		})
 	})
 })
+
+func getFiles(dir string) []string {
+	fileEntries, err := os.ReadDir(dir)
+	Expect(err).ToNot(HaveOccurred())
+	var files []string
+	for _, fileEntry := range fileEntries {
+		files = append(files, fileEntry.Name())
+	}
+	return files
+}
+
+func expectFilesEqual(actualDir, expectedDir string, files []string) {
+	for _, file := range files {
+		Expect(cat(filepath.Join(actualDir, file))).To(Equal(cat(filepath.Join(expectedDir, file))))
+	}
+}

--- a/test/init_crossplane_promise_test.go
+++ b/test/init_crossplane_promise_test.go
@@ -87,6 +87,28 @@ var _ = Describe("InitCrossplanePromise", func() {
 				})
 			})
 
+			When("the XRD file have an empty openAPIV3Schema", func() {
+				BeforeEach(func() {
+					r.flags["--xrd"] = "assets/crossplane/xrd-with-empty-openAPIV3Schema.yaml"
+					session = r.run(initPromiseCmd...)
+					fileEntries, err := os.ReadDir(workingDir)
+					generatedFiles = []string{}
+					for _, fileEntry := range fileEntries {
+						generatedFiles = append(generatedFiles, fileEntry.Name())
+					}
+					Expect(err).ToNot(HaveOccurred())
+				})
+				It("generates a promise", func() {
+					files := []string{"promise.yaml", "example-resource.yaml", "README.md"}
+					Expect(generatedFiles).To(ConsistOf(files))
+					Expect(cat(filepath.Join(workingDir, "promise.yaml"))).To(Equal(cat("assets/crossplane/expected-output-with-empty-openAPIV3Schema/promise.yaml")))
+					Expect(cat(filepath.Join(workingDir, "example-resource.yaml"))).To(Equal(cat("assets/crossplane/expected-output-with-empty-openAPIV3Schema/example-resource.yaml")))
+					Expect(cat(filepath.Join(workingDir, "README.md"))).To(Equal(cat("assets/crossplane/expected-output-with-empty-openAPIV3Schema/README.md")))
+					Expect(session.Out).To(SatisfyAll(
+						gbytes.Say(`Promise generated successfully.`),
+					))
+				})
+			})
 			When("the XRD file does not have a spec.properties", func() {
 				BeforeEach(func() {
 					r.flags["--xrd"] = "assets/crossplane/xrd-with-no-spec-properties.yaml"


### PR DESCRIPTION
Fixes #86.

This PR adds support for valid XRDs with empty openAPIV3Schema similar below:

```
apiVersion: apiextensions.crossplane.io/v1
kind: CompositeResourceDefinition
metadata:
  name: xobjectstorages.awsblueprints.io
spec:
  claimNames:
    kind: ObjectStorage
    plural: objectstorages
  group: awsblueprints.io
  names:
    kind: XObjectStorage
    plural: xobjectstorages
  connectionSecretKeys:
    - region
    - bucket-name
    - s3-put-policy
  versions:
    - name: v1alpha1
      served: true
      referenceable: true
      schema:
        openAPIV3Schema:
          type: object
```