### PR TITLE
chore: use the RELASE_CREATOR_TOKEN when creating release PRs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Create pending releases
         if: github.ref == 'refs/heads/main'
         env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN: ${{ secrets.RELEASE_CREATOR_TOKEN }}
         run: |
           release-please \
             --token=$TOKEN \
@@ -48,7 +48,7 @@ jobs:
       - name: Update Release PR
         if: github.ref == 'refs/heads/main'
         env:
-          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TOKEN: ${{ secrets.RELEASE_CREATOR_TOKEN }}
         run: |
           release-please \
             --token=$TOKEN \


### PR DESCRIPTION
* by design, pushes perform by the secrets.GITHUB_TOKEN do not trigger other github action workflows. As a result, the tag created in 'Update release PR' was not triggering the Release Kratix CLI action. This has now been updated to use the releaser token
* https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication\#using-the-github_token-in-a-workflow