### PR TITLE
fix: add container --python templates

### DIFF
--- a/cmd/templates/workflows/python/Dockerfile.tpl
+++ b/cmd/templates/workflows/python/Dockerfile.tpl
@@ -4,8 +4,7 @@ RUN apt-get update && apt-get install -y git
 
 RUN python -m pip install git+https://github.com/syntasso/kratix-python.git
 
-COPY scripts/pipeline.py /usr/bin/pipeline.py
+WORKDIR /app
+COPY scripts/pipeline.py /app/pipeline.py
 
-CMD [ "sh", "-c", "pipeline.py" ]
-
-ENTRYPOINT []
+ENTRYPOINT ["python", "-u", "/app/pipeline.py"]

--- a/cmd/templates/workflows/python/pipeline.py.tpl
+++ b/cmd/templates/workflows/python/pipeline.py.tpl
@@ -1,12 +1,12 @@
 import kratix_sdk as ks
 
 def main():
-	sdk = ks.KratixSDK()
-	if workflow_action() == "promise":
-		print(f'Hello from {sdk.promise_name()}')
-	else:
-		resource = sdk.read_resource_input()
-		print(f'Hello from {resource.get_name()} {resource.get_namespace()}')
+    sdk = ks.KratixSDK()
+    if sdk.workflow_type() == "promise":
+        print(f'Hello from {sdk.promise_name()}')
+    else:
+        resource = sdk.read_resource_input()
+        print(f'Hello from {resource.get_name()} {resource.get_namespace()}')
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
## Context

When running the generated python configure workflow directly, it fails to execute:
```
❯ k logs kratix-database-example-database-database-configure-16fed-qrnvx -c kratix-demo-resource-pipeline
sh: 1: pipeline.py: Permission denied
```

This PR changes the Dockerfile, use `workflow_type()` from the sdk to get workflow type, and convert the generated `pipeline.py` indentation to all spaces rather than tabs. 