### PR TITLE
feat: kratix cli supports plugins

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -1,0 +1,228 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(newPluginCommand())
+}
+
+func newPluginCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "plugin",
+		Short: "Provides utilities for interacting with plugins",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cmd.Help()
+		},
+	}
+
+	cmd.AddCommand(newPluginListCommand())
+	return cmd
+}
+
+type PluginListOptions struct {
+	Verifier    PathVerifier
+	PluginPaths []string
+
+	Out    io.Writer
+	ErrOut io.Writer
+}
+
+func newPluginListCommand() *cobra.Command {
+	o := &PluginListOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List all visible plugin executables on a user's PATH",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			o.Out = cmd.OutOrStdout()
+			o.ErrOut = cmd.ErrOrStderr()
+			if err := o.Complete(cmd); err != nil {
+				return err
+			}
+			return o.Run()
+		},
+	}
+
+	return cmd
+}
+
+func (o *PluginListOptions) Complete(cmd *cobra.Command) error {
+	o.Verifier = &CommandOverrideVerifier{root: cmd.Root(), seenPlugins: map[string]string{}}
+	o.PluginPaths = filepath.SplitList(os.Getenv("PATH"))
+	if o.Out == nil {
+		o.Out = cmd.OutOrStdout()
+	}
+	if o.ErrOut == nil {
+		o.ErrOut = cmd.ErrOrStderr()
+	}
+	return nil
+}
+
+func (o *PluginListOptions) Run() error {
+	plugins, pluginErrors := o.ListPlugins()
+
+	if len(plugins) > 0 {
+		fmt.Fprintf(o.Out, "The following compatible plugins are available:\n\n")
+	} else {
+		pluginErrors = append(pluginErrors, fmt.Errorf("error: unable to find any kratix plugins in your PATH"))
+	}
+
+	pluginWarnings := 0
+	for _, pluginPath := range plugins {
+		fmt.Fprintf(o.Out, "%s\n", pluginPath)
+		if errs := o.Verifier.Verify(pluginPath); len(errs) != 0 {
+			for _, err := range errs {
+				fmt.Fprintf(o.ErrOut, "  - %s\n", err)
+				pluginWarnings++
+			}
+		}
+	}
+
+	if pluginWarnings > 0 {
+		if pluginWarnings == 1 {
+			pluginErrors = append(pluginErrors, fmt.Errorf("error: one plugin warning was found"))
+		} else {
+			pluginErrors = append(pluginErrors, fmt.Errorf("error: %d plugin warnings were found", pluginWarnings))
+		}
+	}
+
+	if len(pluginErrors) > 0 {
+		buf := bytes.NewBuffer(nil)
+		for _, e := range pluginErrors {
+			fmt.Fprintln(buf, e)
+		}
+		return fmt.Errorf("%s", buf.String())
+	}
+
+	return nil
+}
+
+func (o *PluginListOptions) ListPlugins() ([]string, []error) {
+	var plugins []string
+	var errs []error
+
+	for _, dir := range uniquePathsList(o.PluginPaths) {
+		if strings.TrimSpace(dir) == "" {
+			continue
+		}
+
+		files, err := os.ReadDir(dir)
+		if err != nil {
+			var pathErr *os.PathError
+			if errors.As(err, &pathErr) {
+				fmt.Fprintf(o.ErrOut, "Unable to read directory %q from your PATH: %v. Skipping...\n", dir, err)
+				continue
+			}
+
+			errs = append(errs, fmt.Errorf("error: unable to read directory %q in your PATH: %v", dir, err))
+			continue
+		}
+
+		for _, f := range files {
+			if f.IsDir() {
+				continue
+			}
+			if !hasValidPrefix(f.Name()) {
+				continue
+			}
+
+			fullPath := filepath.Join(dir, f.Name())
+			if ok, err := isExecutable(fullPath); err != nil {
+				errs = append(errs, fmt.Errorf("error: unable to identify %s as an executable file: %v", fullPath, err))
+				continue
+			} else if !ok {
+				fmt.Fprintf(o.ErrOut, "Skipping plugin %q as it is not executable\n", fullPath)
+				continue
+			}
+
+			plugins = append(plugins, fullPath)
+		}
+	}
+
+	return plugins, errs
+}
+
+type PathVerifier interface {
+	Verify(path string) []error
+}
+
+type CommandOverrideVerifier struct {
+	root        *cobra.Command
+	seenPlugins map[string]string
+}
+
+func (v *CommandOverrideVerifier) Verify(path string) []error {
+	if v.root == nil {
+		return []error{fmt.Errorf("unable to verify path with nil root")}
+	}
+
+	binName := filepath.Base(path)
+
+	cmdPath := strings.Split(binName, "-")
+	if len(cmdPath) > 1 {
+		cmdPath = cmdPath[1:]
+	}
+
+	var errs []error
+
+	if existingPath, ok := v.seenPlugins[binName]; ok {
+		errs = append(errs, fmt.Errorf("warning: %s is overshadowed by a similarly named plugin: %s", path, existingPath))
+	} else {
+		v.seenPlugins[binName] = path
+	}
+
+	if cmd, _, err := v.root.Find(cmdPath); err == nil {
+		errs = append(errs, fmt.Errorf("warning: %s overwrites existing command: %q", binName, cmd.CommandPath()))
+	}
+
+	if ok, err := isExecutable(path); err == nil && !ok {
+		errs = append(errs, fmt.Errorf("warning: %s identified as a kratix plugin, but it is not executable", path))
+	} else if err != nil {
+		errs = append(errs, fmt.Errorf("error: unable to identify %s as an executable file: %v", path, err))
+	}
+
+	return errs
+}
+
+func isExecutable(fullPath string) (bool, error) {
+	info, err := os.Stat(fullPath)
+	if err != nil {
+		return false, err
+	}
+	
+	if m := info.Mode(); !m.IsDir() && m&0o111 != 0 {
+		return true, nil
+	}
+
+	return false, nil
+}
+
+func uniquePathsList(paths []string) []string {
+	seen := map[string]bool{}
+	var newPaths []string
+	for _, p := range paths {
+		if seen[p] {
+			continue
+		}
+		seen[p] = true
+		newPaths = append(newPaths, p)
+	}
+	return newPaths
+}
+
+func hasValidPrefix(filename string) bool {
+	if strings.HasPrefix(filename, PluginPrefix+"-") {
+		return true
+	}
+	return false
+}

--- a/cmd/plugin_handler.go
+++ b/cmd/plugin_handler.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+const PluginPrefix = "kratix"
+
+// PluginHandler is capable of parsing command line arguments and performing
+// executable filename lookups to search for valid plugin files, and execute
+// found plugins.
+type PluginHandler interface {
+	Lookup(filename string) (string, bool)
+	Execute(executablePath string, cmdArgs, environment []string) error
+}
+
+// DefaultPluginHandler implements PluginHandler
+type DefaultPluginHandler struct {
+	ValidPrefixes []string
+}
+
+// NewDefaultPluginHandler instantiates the DefaultPluginHandler with a list of
+// given filename prefixes used to identify valid plugin filenames.
+func NewDefaultPluginHandler(validPrefixes []string) *DefaultPluginHandler {
+	return &DefaultPluginHandler{ValidPrefixes: validPrefixes}
+}
+
+// Lookup implements PluginHandler and attempts to locate an executable with the
+// provided filename using the configured prefixes.
+func (h *DefaultPluginHandler) Lookup(filename string) (string, bool) {
+	for _, prefix := range h.ValidPrefixes {
+		path, err := exec.LookPath(fmt.Sprintf("%s-%s", prefix, filename))
+		if err != nil || len(path) == 0 {
+			continue
+		}
+		return path, true
+	}
+	return "", false
+}
+
+// Command returns an exec.Cmd configured with the provided executable path and
+// arguments. It mirrors the helper used by kubectl to retain behaviour on
+// Windows where LookPath may resolve executable extensions.
+func Command(name string, arg ...string) *exec.Cmd {
+	cmd := &exec.Cmd{
+		Path: name,
+		Args: append([]string{name}, arg...),
+	}
+	if filepath.Base(name) == name {
+		if lp, err := exec.LookPath(name); err == nil && lp != "" {
+			cmd.Path = lp
+		}
+	}
+	return cmd
+}
+
+// Execute implements PluginHandler and executes the plugin binary with the
+// provided arguments.
+func (h *DefaultPluginHandler) Execute(executablePath string, cmdArgs, environment []string) error {
+	return syscall.Exec(executablePath, append([]string{executablePath}, cmdArgs...), environment)
+}
+
+// HandlePluginCommand receives a pluginHandler and command-line arguments and
+// attempts to find a plugin executable on the PATH that satisfies the given
+// arguments. If a matching plugin is found it is executed and this function does
+// not return unless an error occurs.
+func HandlePluginCommand(pluginHandler PluginHandler, cmdArgs []string, minArgs int) error {
+	var remainingArgs []string
+	for _, arg := range cmdArgs {
+		if strings.HasPrefix(arg, "-") {
+			break
+		}
+		remainingArgs = append(remainingArgs, strings.ReplaceAll(arg, "-", "_"))
+	}
+
+	if len(remainingArgs) == 0 {
+		return fmt.Errorf("flags cannot be placed before plugin name: %s", cmdArgs[0])
+	}
+
+	var foundBinaryPath string
+	for len(remainingArgs) > 0 {
+		if path, found := pluginHandler.Lookup(strings.Join(remainingArgs, "-")); found {
+			foundBinaryPath = path
+			break
+		}
+		remainingArgs = remainingArgs[:len(remainingArgs)-1]
+		if len(remainingArgs) < minArgs {
+			break
+		}
+	}
+
+	if len(foundBinaryPath) == 0 {
+		return nil
+	}
+
+	if err := pluginHandler.Execute(foundBinaryPath, cmdArgs[len(remainingArgs):], os.Environ()); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/go.sum
+++ b/go.sum
@@ -1167,7 +1167,6 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/syntasso/kratix v0.125.1-0.20250923144917-71691d914142 h1:cGUkrqv++BTUTv31bQOySDWc5JBsv/nynrQ2erlgq3c=
 github.com/syntasso/kratix v0.125.1-0.20250923144917-71691d914142/go.mod h1:O4eD0l8ESDhbdqySlZ2VMfrRdS8B/T8ZXUKbb1sEpAo=
-github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/ulikunitz/xz v0.5.15 h1:9DNdB5s+SgV3bQ2ApL10xRc35ck0DuIX/isZvIk+ubY=
 github.com/ulikunitz/xz v0.5.15/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -1,0 +1,116 @@
+package integration_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+)
+
+var _ = Describe("plugin", func() {
+	var workingDir string
+	var r *runner
+
+	BeforeEach(func() {
+		var err error
+		workingDir, err = os.MkdirTemp("", "kratix-test")
+		Expect(err).NotTo(HaveOccurred())
+		r = &runner{exitCode: 0, dir: workingDir}
+	})
+
+	AfterEach(func() {
+		Expect(os.RemoveAll(workingDir)).To(Succeed())
+	})
+
+	When("called without a subcommand", func() {
+		It("prints the help", func() {
+			session := r.run("plugin")
+			Expect(session.Out).To(SatisfyAll(
+				gbytes.Say("Provides utilities for interacting with plugins"),
+				gbytes.Say("list        List all visible plugin executables on a user's PATH"),
+			))
+		})
+	})
+
+	Context("list", func() {
+		When("there is no plugin found in PATH", func() {
+			It("errors and prints a message", func() {
+				r.exitCode = 1
+				session := r.run("plugin", "list")
+				Expect(session.Err).To(gbytes.Say("error: unable to find any kratix plugins in your PATH"))
+			})
+		})
+
+		When("there are plugins in PATH", func() {
+			BeforeEach(func() {
+				createPlugins(workingDir)
+				r = &runner{exitCode: 0, dir: workingDir, Path: workingDir}
+			})
+			It("lists them", func() {
+				sess := r.run("plugin", "list")
+				Expect(sess.Out).To(SatisfyAll(
+					gbytes.Say("The following compatible plugins are available:"),
+					gbytes.Say("kratix-cat"),
+					gbytes.Say("kratix-error"),
+					gbytes.Say("kratix-hi"),
+				))
+			})
+		})
+	})
+
+	Context("execute", func() {
+		When("there are plugins in PATH", func() {
+			BeforeEach(func() {
+				createPlugins(workingDir)
+				r = &runner{exitCode: 0, dir: workingDir, Path: workingDir}
+			})
+
+			It("can execute them", func() {
+				By("running plugins successfully")
+				sess := r.run("hi")
+				Expect(sess.Out).To(gbytes.Say("have a nice day"))
+
+				sess = r.run("cat")
+				Expect(sess.Out).To(gbytes.Say("meow meow meow"))
+
+				By("preserving the exit code when plugin failed")
+				r.exitCode = 127
+				sess = r.run("error")
+				Expect(sess.Out).To(gbytes.Say("blah"))
+			})
+		})
+	})
+})
+
+func createPlugins(dir string) {
+	script1 := "#!/bin/sh\n" +
+		"echo \"meow meow meow\"\n"
+	script2 := "#!/bin/sh\n" +
+		"echo \"have a nice day\"\n"
+	script3 := "#!/bin/sh\n" +
+		"echo \"blah\" && exit 127\n"
+
+	writePluginFile(filepath.Join(dir, "kratix-cat"), script1)
+	writePluginFile(filepath.Join(dir, "kratix-hi"), script2)
+	writePluginFile(filepath.Join(dir, "kratix-error"), script3)
+}
+
+func writePluginFile(path, script string) {
+	var f *os.File
+	var err error
+	if f, err = os.Create(path); err != nil {
+		ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	}
+
+	defer f.Close()
+
+	_, err = f.WriteString(script)
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	ExpectWithOffset(1, f.Sync()).To(Succeed())
+	ExpectWithOffset(1, f.Close()).To(Succeed())
+
+	// rwxr-xr-x
+	ExpectWithOffset(1, os.Chmod(f.Name(), 0o755)).To(Succeed())
+}

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -35,6 +35,7 @@ type runner struct {
 	flags    map[string]string
 	timeout  time.Duration
 	noPath   bool
+	Path     string
 }
 
 func withExitCode(exitCode int) *runner {
@@ -55,10 +56,15 @@ func (r *runner) run(args ...string) *gexec.Session {
 
 	testBin, err := filepath.Abs("assets/binaries")
 	ExpectWithOffset(1, err).NotTo(HaveOccurred())
-	cmdPath := testBin + ":" + os.Getenv("PATH")
-	if r.noPath {
-		cmdPath = ""
+
+	cmdPath := r.Path
+	if r.Path == "" {
+		cmdPath = testBin + ":" + os.Getenv("PATH")
+		if r.noPath {
+			cmdPath = ""
+		}
 	}
+
 	cmd.Env = append(cmd.Env, "PATH="+cmdPath)
 
 	session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)


### PR DESCRIPTION
## Context

closes #140

```
❯ ./bin/kratix cat
meow meow meow

❯ ./bin/kratix hi
hi! have a good day

❯ ./bin/kratix plugin list
Unable to read directory "/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin" from your PATH: open /var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin: no such file or directory. Skipping...
...
The following compatible plugins are available:

/usr/local/bin/kratix-cat
/usr/local/bin/kratix-hi
```