### PR TITLE
fix: do not assume terraform module source protocol

### DIFF
--- a/stages/terraform-module-promise/main.go
+++ b/stages/terraform-module-promise/main.go
@@ -44,10 +44,11 @@ func main() {
 
 	uniqueFileName := strings.ToLower(fmt.Sprintf("%s_%s_%s", kind, namespace, name))
 
-	source := fmt.Sprintf("git::%s//%s?ref=%s", moduleSource, modulePath, moduleVersion)
+	source := fmt.Sprintf("%s//%s?ref=%s", moduleSource, modulePath, moduleVersion)
 	if modulePath == "" {
-		source = fmt.Sprintf("git::%s?ref=%s", moduleSource, moduleVersion)
+		source = fmt.Sprintf("%s?ref=%s", moduleSource, moduleVersion)
 	}
+
 	module := map[string]map[string]map[string]any{
 		"module": {
 			uniqueFileName: {

--- a/stages/terraform-module-promise/test/stage_test.go
+++ b/stages/terraform-module-promise/test/stage_test.go
@@ -74,7 +74,7 @@ var _ = Describe("From TF module to Promise Stage", func() {
 		envVars = map[string]string{
 			"KRATIX_INPUT_FILE": "assets/test-object.yaml",
 			"KRATIX_OUTPUT_DIR": tmpDir,
-			"MODULE_SOURCE":     "example.com",
+			"MODULE_SOURCE":     "git::example.com",
 			"MODULE_VERSION":    "1.0.0",
 		}
 


### PR DESCRIPTION
# Context

When referring to a terraform module that's from a registry, you don't always need to specify a protocol.

For example, from terraform documentation:

> For modules hosted in other registries, prefix the source address with an additional <HOSTNAME>/ portion, giving the hostname of the private registry:

```
module "consul" {
  source = "app.terraform.io/example-corp/k8s-cluster/azurerm"
  version = "1.1.0"
}
```

Other than `::git`, there's other protocol supported as well (`https`, or `hg`). This commit remove the hardcoded `git::`, so people have the flexibility to configure the full source themselves.

Terraform docs: https://developer.hashicorp.com/terraform/language/v1.9.x/modules/sources?utm_source=chatgpt.com#terraform-registry
https://developer.hashicorp.com/terraform/language/v1.9.x/modules/sources?utm_source=chatgpt.com#generic-git-repository
