### PR TITLE
chore: install python SDK from pypi instead of github

### DIFF
--- a/cmd/templates/workflows/python/Dockerfile.tpl
+++ b/cmd/templates/workflows/python/Dockerfile.tpl
@@ -1,8 +1,6 @@
 FROM python:3.12-slim
 
-RUN apt-get update && apt-get install -y git
-
-RUN python -m pip install git+https://github.com/syntasso/kratix-python.git
+RUN python -m pip install kratix-sdk
 
 WORKDIR /app
 COPY scripts/pipeline.py /app/pipeline.py


### PR DESCRIPTION
# Context

Install python SDK from pypi instead of github. This mean we no longer need to install `git` in dockerfile either.

Builds just fine
```
❯ docker build . -t test:latest
[+] Building 12.9s (9/9) FINISHED                                                                                                                                                                                      docker:desktop-linux
 => [internal] load build definition from Dockerfile                                                                                                                                                                                   0.0s
 => => transferring dockerfile: 240B                                                                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/python:3.12-slim                                                                                                                                                                    2.4s
 => [internal] load .dockerignore                                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                                        0.0s
 => [1/4] FROM docker.io/library/python:3.12-slim@sha256:b43ff04d5df04ad5cabb80890b7ef74e8410e3395b19af970dcd52d7a4bff921                                                                                                              4.5s
 => => resolve docker.io/library/python:3.12-slim@sha256:b43ff04d5df04ad5cabb80890b7ef74e8410e3395b19af970dcd52d7a4bff921                                                                                                              0.0s
 => => sha256:b89cf3ec7a3ed3a58015edd6724125187f0d284147e09b5739b511c74222b2a4 30.14MB / 30.14MB                                                                                                                                       2.4s
 => => sha256:f93b8e9f9a9ccdf3fb7fc430056982ca4f7484e401a3a99254ed7ddf7d6e4931 1.27MB / 1.27MB                                                                                                                                         0.9s
 => => sha256:ca08f633d74c9eda1148afec7ce13d1a24348bbd6b513909cc95c70e99aec0f2 12.04MB / 12.04MB                                                                                                                                       3.5s
 => => sha256:b43ff04d5df04ad5cabb80890b7ef74e8410e3395b19af970dcd52d7a4bff921 10.37kB / 10.37kB                                                                                                                                       0.0s
 => => sha256:4c788dbba1476d9cc6196e9a82096e6c53a45b67f557a44b31f70d7dad572425 1.75kB / 1.75kB                                                                                                                                         0.0s
 => => sha256:bf35ad083b068a4a06f0856286261d1731803da095a9b53e4d1d41597b09a743 5.69kB / 5.69kB                                                                                                                                         0.0s
 => => sha256:4ba8419e34661c34728c62ef23a3309d0196c59aa6a83fa8640f26503e75b6c2 250B / 250B                                                                                                                                             1.2s
 => => extracting sha256:b89cf3ec7a3ed3a58015edd6724125187f0d284147e09b5739b511c74222b2a4                                                                                                                                              1.3s
 => => extracting sha256:f93b8e9f9a9ccdf3fb7fc430056982ca4f7484e401a3a99254ed7ddf7d6e4931                                                                                                                                              0.1s
 => => extracting sha256:ca08f633d74c9eda1148afec7ce13d1a24348bbd6b513909cc95c70e99aec0f2                                                                                                                                              0.6s
 => => extracting sha256:4ba8419e34661c34728c62ef23a3309d0196c59aa6a83fa8640f26503e75b6c2                                                                                                                                              0.0s
 => [internal] load build context                                                                                                                                                                                                      0.0s
 => => transferring context: 396B                                                                                                                                                                                                      0.0s
 => [2/4] RUN python -m pip install kratix-sdk                                                                                                                                                                                         5.6s
 => [3/4] WORKDIR /app                                                                                                                                                                                                                 0.0s
 => [4/4] COPY scripts/pipeline.py /app/pipeline.py                                                                                                                                                                                    0.0s
 => exporting to image                                                                                                                                                                                                                 0.2s
 => => exporting layers                                                                                                                                                                                                                0.2s
 => => writing image sha256:07e5253654511e68431dba9aafd7009583f451b4c85eb902e7d5074ba76a4e62                                                                                                                                           0.0s
 => => naming to docker.io/library/test:latest
```