### PR TITLE
fix: accept YAML Pulumi schemas from URLs

### DIFF
--- a/cmd/kratix/main.go
+++ b/cmd/kratix/main.go
@@ -21,7 +21,7 @@ import (
 )
 
 // needs to be updated before cutting a new release to desired version and should match the next version in .release-please-manifest.json
-var version = "0.16.0"
+var version = "0.17.0"
 
 func main() {
 	cmd.Execute(version)

--- a/cmd/pulumi_stage_defaults.go
+++ b/cmd/pulumi_stage_defaults.go
@@ -2,7 +2,7 @@ package cmd
 
 const (
 	pulumiGeneratorImageRepository = "ghcr.io/syntasso/kratix-cli/pulumi-generator"
-	pulumiGeneratorImageVersion    = "v0.1.2"
+	pulumiGeneratorImageVersion    = "v0.1.3"
 
 	pulumiProgramGeneratorContainerName = "pulumi-program-generator"
 	pulumiStackGeneratorContainerName   = "pulumi-stack-generator"

--- a/internal/pulumi/schema_loader.go
+++ b/internal/pulumi/schema_loader.go
@@ -59,18 +59,14 @@ func LoadSchema(source string) (SchemaDocument, error) {
 }
 
 func parseSchemaDocument(rawSchema []byte) (SchemaDocument, error) {
+	jsonBytes, err := yaml.YAMLToJSON(rawSchema)
+	if err != nil {
+		return SchemaDocument{}, fmt.Errorf("load schema: parse input schema as JSON or YAML: %w", err)
+	}
+
 	var doc SchemaDocument
-	if err := json.Unmarshal(rawSchema, &doc); err != nil {
-		jsonErr := err
-
-		jsonSchema, err := yaml.YAMLToJSON(rawSchema)
-		if err != nil {
-			return SchemaDocument{}, fmt.Errorf("load schema: parse input schema as JSON or YAML: %v", jsonErr)
-		}
-
-		if err := json.Unmarshal(jsonSchema, &doc); err != nil {
-			return SchemaDocument{}, fmt.Errorf("load schema: parse input schema as JSON or YAML: %v", jsonErr)
-		}
+	if err := json.Unmarshal(jsonBytes, &doc); err != nil {
+		return SchemaDocument{}, fmt.Errorf("load schema: parse input schema as JSON or YAML: %w", err)
 	}
 
 	return doc, nil

--- a/internal/pulumi/schema_loader.go
+++ b/internal/pulumi/schema_loader.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"sigs.k8s.io/yaml"
 )
 
 const schemaURLTimeout = 15 * time.Second
@@ -48,9 +50,27 @@ func LoadSchema(source string) (SchemaDocument, error) {
 		return SchemaDocument{}, err
 	}
 
+	doc, err := parseSchemaDocument(rawSchema)
+	if err != nil {
+		return SchemaDocument{}, err
+	}
+
+	return doc, nil
+}
+
+func parseSchemaDocument(rawSchema []byte) (SchemaDocument, error) {
 	var doc SchemaDocument
 	if err := json.Unmarshal(rawSchema, &doc); err != nil {
-		return SchemaDocument{}, fmt.Errorf("load schema: parse input schema as JSON: %w", err)
+		jsonErr := err
+
+		jsonSchema, err := yaml.YAMLToJSON(rawSchema)
+		if err != nil {
+			return SchemaDocument{}, fmt.Errorf("load schema: parse input schema as JSON or YAML: %v", jsonErr)
+		}
+
+		if err := json.Unmarshal(jsonSchema, &doc); err != nil {
+			return SchemaDocument{}, fmt.Errorf("load schema: parse input schema as JSON or YAML: %v", jsonErr)
+		}
 	}
 
 	return doc, nil

--- a/internal/pulumi/schema_loader_test.go
+++ b/internal/pulumi/schema_loader_test.go
@@ -30,6 +30,30 @@ func TestLoadSchema(t *testing.T) {
 		}
 	})
 
+	t.Run("loads local YAML file", func(t *testing.T) {
+		t.Parallel()
+
+		tempDir := t.TempDir()
+		schemaPath := filepath.Join(tempDir, "schema.yaml")
+		schemaBody := `
+name: pkg
+resources:
+  pkg:index:Thing:
+    isComponent: true
+`
+		if err := os.WriteFile(schemaPath, []byte(schemaBody), 0o600); err != nil {
+			t.Fatalf("write schema fixture: %v", err)
+		}
+
+		doc, err := LoadSchema(schemaPath)
+		if err != nil {
+			t.Fatalf("LoadSchema returned error: %v", err)
+		}
+		if !doc.Resources["pkg:index:Thing"].IsComponent {
+			t.Fatalf("expected pkg:index:Thing to be a component")
+		}
+	})
+
 	t.Run("loads URL", func(t *testing.T) {
 		t.Parallel()
 
@@ -67,7 +91,7 @@ func TestLoadSchema(t *testing.T) {
 		}
 
 		_, err := LoadSchema(schemaPath)
-		if err == nil || !strings.Contains(err.Error(), "load schema: parse input schema as JSON:") {
+		if err == nil || !strings.Contains(err.Error(), "load schema: parse input schema as JSON or YAML:") {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})

--- a/stages/pulumi-promise/test/stage_test.go
+++ b/stages/pulumi-promise/test/stage_test.go
@@ -135,6 +135,6 @@ var _ = Describe("From request to Pulumi Program stage", func() {
 		session := runWithEnv(envVars)
 
 		Expect(session).To(gexec.Exit(1))
-		Expect(session.Err).To(gbytes.Say("load schema for Program configuration: load schema: parse input schema as JSON"))
+		Expect(session.Err).To(gbytes.Say("load schema for Program configuration: load schema: parse input schema"))
 	})
 })

--- a/test/assets/pulumi/expected-output-with-split/workflows/resource/configure/workflow.yaml
+++ b/test/assets/pulumi/expected-output-with-split/workflows/resource/configure/workflow.yaml
@@ -11,12 +11,12 @@
             value: ./schema.valid.json
         command:
           - /pulumi-program-generator
-        image: ghcr.io/syntasso/kratix-cli/pulumi-generator:v0.1.2
+        image: ghcr.io/syntasso/kratix-cli/pulumi-generator:v0.1.3
         name: pulumi-program-generator
       - env:
           - name: PULUMI_COMPONENT_TOKEN
             value: pkg:index:Database
         command:
           - /pulumi-stack-generator
-        image: ghcr.io/syntasso/kratix-cli/pulumi-generator:v0.1.2
+        image: ghcr.io/syntasso/kratix-cli/pulumi-generator:v0.1.3
         name: pulumi-stack-generator

--- a/test/assets/pulumi/expected-output/promise.yaml
+++ b/test/assets/pulumi/expected-output/promise.yaml
@@ -76,14 +76,14 @@ spec:
                     value: ./schema.valid.json
                 command:
                   - /pulumi-program-generator
-                image: ghcr.io/syntasso/kratix-cli/pulumi-generator:v0.1.2
+                image: ghcr.io/syntasso/kratix-cli/pulumi-generator:v0.1.3
                 name: pulumi-program-generator
               - env:
                   - name: PULUMI_COMPONENT_TOKEN
                     value: pkg:index:Database
                 command:
                   - /pulumi-stack-generator
-                image: ghcr.io/syntasso/kratix-cli/pulumi-generator:v0.1.2
+                image: ghcr.io/syntasso/kratix-cli/pulumi-generator:v0.1.3
                 name: pulumi-stack-generator
 status:
   workflows: 0

--- a/test/init_pulumi_component_promise_test.go
+++ b/test/init_pulumi_component_promise_test.go
@@ -212,6 +212,36 @@ var _ = Describe("init pulumi-component-promise", func() {
 		Expect(session.Err).NotTo(gbytes.Say("Error:"))
 	})
 
+	It("loads YAML schema from URL and generates Promise files", func() {
+		schemaURL := "https://schemas.example.test/schema.yaml"
+		schemaBody := `
+name: pkg
+resources:
+  pkg:index:Thing:
+    isComponent: true
+    inputProperties:
+      name:
+        type: string
+    requiredInputs:
+      - name
+`
+		r.env = []string{
+			"KRATIX_TEST_SCHEMA_URL=" + schemaURL,
+			"KRATIX_TEST_SCHEMA_URL_BODY=" + schemaBody,
+		}
+
+		session := r.run(
+			"init", "pulumi-component-promise", "mypromise",
+			"--schema", schemaURL,
+			"--group", "syntasso.io",
+			"--kind", "Database",
+		)
+
+		Expect(getFiles(workingDir)).To(ContainElements("promise.yaml", "example-resource.yaml", "README.md"))
+		Expect(session.Out).To(gbytes.Say("Pulumi component Promise generated successfully."))
+		Expect(session.Err).NotTo(gbytes.Say("Error:"))
+	})
+
 	It("fails for non-200 URL status while loading schema", func() {
 		schemaURL := "https://schemas.example.test/not-found.json"
 		failingRunner := withExitCode(1)
@@ -496,7 +526,7 @@ var _ = Describe("init pulumi-component-promise", func() {
 			"--group", "syntasso.io",
 			"--kind", "Database",
 		)
-		Expect(session.Err).To(gbytes.Say(`Error: load schema: parse input schema as JSON:`))
+		Expect(session.Err).To(gbytes.Say(`Error: load schema: parse input schema as JSON or YAML:`))
 	})
 
 	It("fails for unsupported schema URL scheme", func() {


### PR DESCRIPTION
The following command was used as an example during initial testing:
```
kratix init pulumi-component-promise iam-user \
    --schema "https://www.pulumi.com/registry/packages/aws-iam/schema.json" \
    --component "aws-iam:index:User" \
    --group syntasso.io \
    --kind User \
    --dir pulumi-user
```

On running that today, there was an issue because of the top lines on the url:
```
# yaml-language-server: $schema=https://raw.githubusercontent.com/pulumi/pulumi/master/pkg/codegen/schema/pulumi.json
---
name: aws-iam
types:
    "aws-iam:index:AccountPasswordPolicy":
        type: object
        description: Options to specify complexity requirements and mandatory rotation periods for your IAM users' passwords.
        properties:
...
```

Note this now also breaks pretty print JSON in the browser:
<img width="1388" height="476" alt="image" src="https://github.com/user-attachments/assets/1eaa48a9-c594-4120-ae8b-45d0303d6954" />


There is no indication that the format of this file has changed in commits, but just experience reports that this used to work. Either way, we can be more robust in managing yaml or json inputs which is what this fix does.

Examples of this working on local branch build for both the "happy" path and a missing "component" flag path:
<img width="1704" height="639" alt="image" src="https://github.com/user-attachments/assets/8433f92f-6a63-4529-bf44-1482eaa41b3c" />

Proof of generated promise at time of run:
<img width="800" height="188" alt="image" src="https://github.com/user-attachments/assets/f0537548-b3bb-4f57-896c-badb219490c7" />
