### PR TITLE
chore: build destination selectors into pulumi init

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,8 +1,8 @@
 {
-    ".": "0.16.1",
+    ".": "0.16.2",
     "stages/helm-promise": "0.3.1",
     "stages/terraform-module-promise": "0.6.0",
     "stages/operator-promise": "0.3.1",
     "stages/crossplane-promise": "0.2.2",
-    "stages/pulumi-promise": "0.1.3"
+    "stages/pulumi-promise": "0.1.4"
 }

--- a/cmd/init_pulumi_component_promise.go
+++ b/cmd/init_pulumi_component_promise.go
@@ -33,6 +33,8 @@ var (
 	pulumiComponent               string
 	pulumiSchemaBearerTokenSecret string
 	pulumiStackAccessTokenSecret  string
+
+	pulumiDestinationSelectors = []v1alpha1.PromiseScheduling{{MatchLabels: map[string]string{"environment": "pulumi"}}}
 )
 
 type pulumiPromiseTemplateValues struct {
@@ -191,7 +193,7 @@ func initPulumiComponentPromiseFromSelection(promiseName string, component pulum
 		split,
 		workflowDirectory,
 		extraFlags,
-		nil,
+		pulumiDestinationSelectors,
 		[]v1alpha1.Dependency{},
 		crd,
 		pipelines,

--- a/cmd/kratix/main.go
+++ b/cmd/kratix/main.go
@@ -21,7 +21,7 @@ import (
 )
 
 // needs to be updated before cutting a new release to desired version and should match the next version in .release-please-manifest.json
-var version = "0.16.1"
+var version = "0.16.2"
 
 func main() {
 	cmd.Execute(version)

--- a/cmd/pulumi_stage_defaults.go
+++ b/cmd/pulumi_stage_defaults.go
@@ -2,7 +2,7 @@ package cmd
 
 const (
 	pulumiGeneratorImageRepository = "ghcr.io/syntasso/kratix-cli/pulumi-generator"
-	pulumiGeneratorImageVersion    = "v0.1.3"
+	pulumiGeneratorImageVersion    = "v0.1.4"
 
 	pulumiProgramGeneratorContainerName = "pulumi-program-generator"
 	pulumiStackGeneratorContainerName   = "pulumi-stack-generator"

--- a/test/assets/pulumi/expected-output-with-split/workflows/resource/configure/workflow.yaml
+++ b/test/assets/pulumi/expected-output-with-split/workflows/resource/configure/workflow.yaml
@@ -11,12 +11,12 @@
             value: ./schema.valid.json
         command:
           - /pulumi-program-generator
-        image: ghcr.io/syntasso/kratix-cli/pulumi-generator:v0.1.3
+        image: ghcr.io/syntasso/kratix-cli/pulumi-generator:v0.1.4
         name: pulumi-program-generator
       - env:
           - name: PULUMI_COMPONENT_TOKEN
             value: pkg:index:Database
         command:
           - /pulumi-stack-generator
-        image: ghcr.io/syntasso/kratix-cli/pulumi-generator:v0.1.3
+        image: ghcr.io/syntasso/kratix-cli/pulumi-generator:v0.1.4
         name: pulumi-stack-generator

--- a/test/assets/pulumi/expected-output/promise.yaml
+++ b/test/assets/pulumi/expected-output/promise.yaml
@@ -58,6 +58,9 @@ spec:
         plural: ""
       conditions: null
       storedVersions: null
+  destinationSelectors:
+    - matchLabels:
+        environment: pulumi
   workflows:
     config: {}
     promise: {}
@@ -76,14 +79,14 @@ spec:
                     value: ./schema.valid.json
                 command:
                   - /pulumi-program-generator
-                image: ghcr.io/syntasso/kratix-cli/pulumi-generator:v0.1.3
+                image: ghcr.io/syntasso/kratix-cli/pulumi-generator:v0.1.4
                 name: pulumi-program-generator
               - env:
                   - name: PULUMI_COMPONENT_TOKEN
                     value: pkg:index:Database
                 command:
                   - /pulumi-stack-generator
-                image: ghcr.io/syntasso/kratix-cli/pulumi-generator:v0.1.3
+                image: ghcr.io/syntasso/kratix-cli/pulumi-generator:v0.1.4
                 name: pulumi-stack-generator
 status:
   workflows: 0

--- a/test/init_pulumi_component_promise_test.go
+++ b/test/init_pulumi_component_promise_test.go
@@ -334,6 +334,7 @@ resources:
 			ContainSubstring("- /pulumi-stack-generator"),
 			ContainSubstring("name: PULUMI_COMPONENT_TOKEN"),
 			ContainSubstring("name: PULUMI_SCHEMA_SOURCE"),
+			ContainSubstring("environment: pulumi"),
 		))
 		Expect(promiseContents).NotTo(ContainSubstring("name: PULUMI_ACCESS_TOKEN"))
 		exampleResourceContents := cat(filepath.Join(workingDir, "example-resource.yaml"))


### PR DESCRIPTION
This should mirror the terraform experience of having a destination selector set by default.