### PR TITLE
chore: improve output for plugin subcommand

### DIFF
--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -79,7 +79,7 @@ func (o *PluginListOptions) Run() error {
 
 	pluginWarnings := 0
 	for _, pluginPath := range plugins {
-		fmt.Fprintf(o.Out, "%s\n", pluginPath)
+		fmt.Fprintf(o.Out, "%-40s (%s)\n", pluginToCommand(pluginPath), filepath.Dir(pluginPath))
 		if errs := o.Verifier.Verify(pluginPath); len(errs) != 0 {
 			for _, err := range errs {
 				fmt.Fprintf(o.ErrOut, "  - %s\n", err)
@@ -120,7 +120,6 @@ func (o *PluginListOptions) ListPlugins() ([]string, []error) {
 		if err != nil {
 			var pathErr *os.PathError
 			if errors.As(err, &pathErr) {
-				fmt.Fprintf(o.ErrOut, "Unable to read directory %q from your PATH: %v. Skipping...\n", dir, err)
 				continue
 			}
 
@@ -235,3 +234,14 @@ func hasValidPrefix(filename string) bool {
 	}
 	return false
 }
+
+func pluginToCommand(pluginPath string) string {
+	name := filepath.Base(pluginPath)
+	name = strings.TrimPrefix(name, PluginPrefix+"-")
+	parts := strings.Split(name, "-")
+	for i, p := range parts {
+		parts[i] = strings.ReplaceAll(p, "_", "-")
+	}
+	return PluginPrefix + " " + strings.Join(parts, " ")
+}
+

--- a/test/plugin_test.go
+++ b/test/plugin_test.go
@@ -54,10 +54,11 @@ var _ = Describe("plugin", func() {
 				sess := r.run("plugin", "list")
 				Expect(sess.Out).To(SatisfyAll(
 					gbytes.Say("The following compatible plugins are available:"),
-					gbytes.Say("kratix-cat"),
-					gbytes.Say("kratix-error"),
-					gbytes.Say("kratix-hi"),
+					gbytes.Say("kratix cat"),
+					gbytes.Say("kratix error"),
+					gbytes.Say("kratix hi"),
 				))
+				Expect(string(sess.Out.Contents())).To(ContainSubstring(workingDir))
 			})
 		})
 
@@ -76,8 +77,7 @@ var _ = Describe("plugin", func() {
 
 				Expect(sess.Err).NotTo(gbytes.Say("overshadowed by a similarly named plugin"))
 
-				pluginPath := filepath.Join(workingDir, "kratix-hi")
-				Expect(strings.Count(string(sess.Out.Contents()), pluginPath)).To(Equal(1))
+				Expect(strings.Count(string(sess.Out.Contents()), "kratix hi")).To(Equal(1))
 			})
 		})
 	})


### PR DESCRIPTION
Example new output:
```
$ ./bin/kratix plugin list
The following compatible plugins are available:

kratix local show promise                (/Users/abbybangser/dev/syntasso/home-scripts)
kratix local show schedule               (/Users/abbybangser/dev/syntasso/home-scripts)
kratix test                              (/Users/abbybangser/dev/syntasso/.kratix/plugins)
```