### PR TITLE
feat(229): terraform-generate image outputs hcl not json

### DIFF
--- a/cmd/templates/promise/README.md.tpl
+++ b/cmd/templates/promise/README.md.tpl
@@ -2,7 +2,7 @@
 
 This Promise was generated with:
 
-```
+```bash
 kratix init {{ .SubCommand }} {{ .Name }} {{ .ExtraFlags }} --group {{ .Group }} --kind {{ .Kind }}
 ```
 
@@ -10,7 +10,7 @@ kratix init {{ .SubCommand }} {{ .Name }} {{ .ExtraFlags }} --group {{ .Group }}
 
 To update the Promise API, you can use the `kratix update api` command:
 
-```
+```bash
 kratix update api --property name:string --property region- --kind {{ .Kind }}
 ```
 
@@ -18,8 +18,20 @@ kratix update api --property name:string --property region- --kind {{ .Kind }}
 
 To add workflow containers, you can use the `kratix add container` command:
 
-```
+```bash
 kratix add container resource/configure/pipeline0 --image syntasso/postgres-resource:v1.0.0
+```
+
+### Building containers
+
+After editing a container's scripts, build and push the image with `kratix build container`:
+
+```bash
+# build a specific container
+kratix build container resource/configure/pipeline0 --name syntasso-postgres-resource
+
+# build all containers across all workflows
+kratix build container --all
 ```
 
 {{- if eq .SubCommand "pulumi-component-promise" }}
@@ -77,11 +89,24 @@ This access is set by a separate environment variables in the `{{ .PulumiStackGe
 - name: PULUMI_STACK_ACCESS_TOKEN_SECRET_KEY
   value: token
 ```
-{{ end }}
 
 For this Stack to work as intended, ensure the referenced Secret is present in the namespace where this Workflow runs.
 This secret can be populated manually or via a new container in the `Workflow.Promise.Configure` field if it is common to all resources or the `Workflow.Resource.Configure` if it is unique per request.
+{{ end }}
+
 
 ## Updating Dependencies
 
-TBD
+To add dependencies to the Promise, via a `promise.configure` workflows or the `spec.dependencies` key, you can use the `kratix update dependencies` command:
+
+```bash
+kratix update dependencies /dependencies-path
+```
+
+## Updating Destination Selectors
+
+To update the Destination Selectors in the Promise Spec, can use the `kratix update destination-selector` flag:
+
+```bash
+kratix update destination-selector env=dev
+```

--- a/stages/terraform-module-promise/main.go
+++ b/stages/terraform-module-promise/main.go
@@ -6,10 +6,12 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/syntasso/kratix-cli/internal"
+	"github.com/zclconf/go-cty/cty"
 	"gopkg.in/yaml.v3"
 )
 
@@ -117,108 +119,67 @@ func runResourceWorkflow(outputDir string) {
 	fmt.Printf("Terraform configuration written to %s\n", path)
 }
 
-// generateHCL produces a native HCL module block (and optional output blocks) from a
-// map[string]any spec. Keys are sorted alphabetically for deterministic output.
 func generateHCL(moduleName, source, version string, spec map[string]any, outputNames []string) []byte {
-	var sb strings.Builder
+	f := hclwrite.NewEmptyFile()
+	rootBody := f.Body()
 
-	fmt.Fprintf(&sb, "module %q {\n", moduleName)
+	moduleBlock := rootBody.AppendNewBlock("module", []string{moduleName})
+	body := moduleBlock.Body()
 
-	// Align "source" and "version" when both are present (terraform fmt convention).
+	body.SetAttributeValue("source", cty.StringVal(source))
 	if version != "" {
-		fmt.Fprintf(&sb, "  source  = %q\n", source)
-		fmt.Fprintf(&sb, "  version = %q\n", version)
-	} else {
-		fmt.Fprintf(&sb, "  source = %q\n", source)
+		body.SetAttributeValue("version", cty.StringVal(version))
 	}
 
 	if len(spec) > 0 {
-		sb.WriteString("\n")
+		body.AppendNewline()
 		for _, k := range sortedKeys(spec) {
-			sb.WriteString("  ")
-			sb.WriteString(k)
-			sb.WriteString(" = ")
-			writeHCLValue(&sb, spec[k], 1)
-			sb.WriteString("\n")
+			body.SetAttributeValue(k, goToCty(spec[k]))
 		}
 	}
-
-	sb.WriteString("}")
 
 	for _, name := range outputNames {
-		fmt.Fprintf(&sb, "\n\noutput %q {\n", moduleName+"_"+name)
-		fmt.Fprintf(&sb, "  value = \"${module.%s.%s}\"\n", moduleName, name)
-		sb.WriteString("}")
+		rootBody.AppendNewline()
+		outputBlock := rootBody.AppendNewBlock("output", []string{moduleName + "_" + name})
+		traversal := hcl.Traversal{
+			hcl.TraverseRoot{Name: "module"},
+			hcl.TraverseAttr{Name: moduleName},
+			hcl.TraverseAttr{Name: name},
+		}
+		outputBlock.Body().SetAttributeRaw("value", hclwrite.TokensForTraversal(traversal))
 	}
 
-	return []byte(sb.String())
+	return f.Bytes()
 }
 
-// writeHCLValue writes a single HCL attribute value at the given indent depth.
-// Primitives are written inline; maps and object-bearing lists use multi-line format.
-func writeHCLValue(sb *strings.Builder, v any, depth int) {
-	indent := strings.Repeat("  ", depth)
-	innerIndent := strings.Repeat("  ", depth+1)
-
+func goToCty(v any) cty.Value {
 	switch val := v.(type) {
 	case string:
-		sb.WriteString(strconv.Quote(val))
+		return cty.StringVal(val)
 	case int:
-		fmt.Fprintf(sb, "%d", val)
+		return cty.NumberIntVal(int64(val))
 	case float64:
-		if val == float64(int64(val)) {
-			fmt.Fprintf(sb, "%d", int64(val))
-		} else {
-			fmt.Fprintf(sb, "%g", val)
-		}
+		return cty.NumberFloatVal(val)
 	case bool:
-		if val {
-			sb.WriteString("true")
-		} else {
-			sb.WriteString("false")
-		}
+		return cty.BoolVal(val)
 	case []any:
-		if len(val) == 0 {
-			sb.WriteString("[]")
-			return
+		vals := make([]cty.Value, len(val))
+		for i, elem := range val {
+			vals[i] = goToCty(elem)
 		}
-		hasObjects := false
-		for _, elem := range val {
-			if _, ok := elem.(map[string]any); ok {
-				hasObjects = true
-				break
-			}
-		}
-		if !hasObjects {
-			sb.WriteString("[")
-			for i, elem := range val {
-				if i > 0 {
-					sb.WriteString(", ")
-				}
-				writeHCLValue(sb, elem, depth)
-			}
-			sb.WriteString("]")
-		} else {
-			sb.WriteString("[\n")
-			for _, elem := range val {
-				sb.WriteString(innerIndent)
-				writeHCLValue(sb, elem, depth+1)
-				sb.WriteString(",\n")
-			}
-			sb.WriteString(indent)
-			sb.WriteString("]")
-		}
+		return cty.TupleVal(vals)
 	case map[string]any:
-		sb.WriteString("{\n")
-		for _, k := range sortedKeys(val) {
-			sb.WriteString(innerIndent)
-			sb.WriteString(k)
-			sb.WriteString(" = ")
-			writeHCLValue(sb, val[k], depth+1)
-			sb.WriteString("\n")
+		if len(val) == 0 {
+			return cty.EmptyObjectVal
 		}
-		sb.WriteString(indent)
-		sb.WriteString("}")
+		attrs := make(map[string]cty.Value, len(val))
+		for k, v := range val {
+			attrs[k] = goToCty(v)
+		}
+		return cty.ObjectVal(attrs)
+	default:
+		log.Fatalf("unsupported value type %T", v)
+		return cty.NilVal
 	}
 }
 

--- a/stages/terraform-module-promise/main.go
+++ b/stages/terraform-module-promise/main.go
@@ -3,9 +3,10 @@ package main
 import (
 	"fmt"
 	"log"
+	"maps"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/hashicorp/hcl/v2"
@@ -133,8 +134,8 @@ func generateHCL(moduleName, source, version string, spec map[string]any, output
 
 	if len(spec) > 0 {
 		body.AppendNewline()
-		for _, k := range sortedKeys(spec) {
-			body.SetAttributeValue(k, goToCty(spec[k]))
+		for _, key := range slices.Sorted(maps.Keys(spec)) {
+			body.SetAttributeValue(key, goToCty(spec[key]))
 		}
 	}
 
@@ -181,13 +182,4 @@ func goToCty(v any) cty.Value {
 		log.Fatalf("unsupported value type %T", v)
 		return cty.NilVal
 	}
-}
-
-func sortedKeys(m map[string]any) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	return keys
 }

--- a/stages/terraform-module-promise/main.go
+++ b/stages/terraform-module-promise/main.go
@@ -1,11 +1,12 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/syntasso/kratix-cli/internal"
@@ -85,59 +86,147 @@ func runResourceWorkflow(outputDir string) {
 
 	uniqueFileName := strings.ToLower(fmt.Sprintf("%s_%s_%s", kind, namespace, name))
 
-	config := map[string]any{
-		"module": map[string]any{
-			uniqueFileName: map[string]any{
-				"source": moduleSource,
-			},
-		},
-	}
-	moduleBlock := config["module"].(map[string]any)
-	moduleInstance := moduleBlock[uniqueFileName].(map[string]any)
-
-	if moduleRegistryVersion != "" {
-		moduleInstance["version"] = moduleRegistryVersion
-	}
-
-	// Handle spec if it exists
-	if spec, ok := inputObjectData["spec"].(map[string]any); ok {
-		for key, value := range spec {
+	spec := make(map[string]any)
+	if specMap, ok := inputObjectData["spec"].(map[string]any); ok {
+		for key, value := range specMap {
 			valSlice, ok := value.([]any)
 			// 1. if its not an array and its not nil, add it to the module
 			// 2. if its an array and its not empty, add it to the module
 			// this gets around adding a bunch of empty arrays to the module
 			if (!ok && value != nil) || (ok && len(valSlice) > 0) {
-				moduleInstance[key] = value
+				spec[key] = value
 			}
 		}
 	}
 
-	if outputNames := parseOutputNames(os.Getenv("MODULE_OUTPUT_NAMES")); len(outputNames) > 0 {
-		outputBlock := make(map[string]any)
-		for _, name := range outputNames {
-			uniqueOutputName := uniqueFileName + "_" + name
-			outputBlock[uniqueOutputName] = map[string]any{
-				"value": fmt.Sprintf("${module.%s.%s}", uniqueFileName, name),
-			}
-		}
-		config["output"] = outputBlock
-	}
+	outputNames := parseOutputNames(os.Getenv("MODULE_OUTPUT_NAMES"))
 
-	jsonData, err := json.MarshalIndent(config, "", "  ")
-	if err != nil {
-		log.Fatalf("Error generating JSON: %v\n", err)
-	}
+	hclData := generateHCL(uniqueFileName, moduleSource, moduleRegistryVersion, spec, outputNames)
 
 	err = os.MkdirAll(outputDir, os.ModePerm)
 	if err != nil {
 		log.Fatalf("Error creating output directory: %v\n", err)
 	}
 
-	path := filepath.Join(outputDir, uniqueFileName+".tf.json")
-	err = os.WriteFile(path, jsonData, 0644)
+	path := filepath.Join(outputDir, uniqueFileName+".tf")
+	err = os.WriteFile(path, hclData, 0644)
 	if err != nil {
-		log.Fatalf("Error writing Terraform JSON file: %v\n", err)
+		log.Fatalf("Error writing Terraform file: %v\n", err)
 	}
 
-	fmt.Printf("Terraform JSON configuration written to %s\n", path)
+	fmt.Printf("Terraform configuration written to %s\n", path)
+}
+
+// generateHCL produces a native HCL module block (and optional output blocks) from a
+// map[string]any spec. Keys are sorted alphabetically for deterministic output.
+func generateHCL(moduleName, source, version string, spec map[string]any, outputNames []string) []byte {
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "module %q {\n", moduleName)
+
+	// Align "source" and "version" when both are present (terraform fmt convention).
+	if version != "" {
+		fmt.Fprintf(&sb, "  source  = %q\n", source)
+		fmt.Fprintf(&sb, "  version = %q\n", version)
+	} else {
+		fmt.Fprintf(&sb, "  source = %q\n", source)
+	}
+
+	if len(spec) > 0 {
+		sb.WriteString("\n")
+		for _, k := range sortedKeys(spec) {
+			sb.WriteString("  ")
+			sb.WriteString(k)
+			sb.WriteString(" = ")
+			writeHCLValue(&sb, spec[k], 1)
+			sb.WriteString("\n")
+		}
+	}
+
+	sb.WriteString("}")
+
+	for _, name := range outputNames {
+		fmt.Fprintf(&sb, "\n\noutput %q {\n", moduleName+"_"+name)
+		fmt.Fprintf(&sb, "  value = \"${module.%s.%s}\"\n", moduleName, name)
+		sb.WriteString("}")
+	}
+
+	return []byte(sb.String())
+}
+
+// writeHCLValue writes a single HCL attribute value at the given indent depth.
+// Primitives are written inline; maps and object-bearing lists use multi-line format.
+func writeHCLValue(sb *strings.Builder, v any, depth int) {
+	indent := strings.Repeat("  ", depth)
+	innerIndent := strings.Repeat("  ", depth+1)
+
+	switch val := v.(type) {
+	case string:
+		sb.WriteString(strconv.Quote(val))
+	case int:
+		fmt.Fprintf(sb, "%d", val)
+	case float64:
+		if val == float64(int64(val)) {
+			fmt.Fprintf(sb, "%d", int64(val))
+		} else {
+			fmt.Fprintf(sb, "%g", val)
+		}
+	case bool:
+		if val {
+			sb.WriteString("true")
+		} else {
+			sb.WriteString("false")
+		}
+	case []any:
+		if len(val) == 0 {
+			sb.WriteString("[]")
+			return
+		}
+		hasObjects := false
+		for _, elem := range val {
+			if _, ok := elem.(map[string]any); ok {
+				hasObjects = true
+				break
+			}
+		}
+		if !hasObjects {
+			sb.WriteString("[")
+			for i, elem := range val {
+				if i > 0 {
+					sb.WriteString(", ")
+				}
+				writeHCLValue(sb, elem, depth)
+			}
+			sb.WriteString("]")
+		} else {
+			sb.WriteString("[\n")
+			for _, elem := range val {
+				sb.WriteString(innerIndent)
+				writeHCLValue(sb, elem, depth+1)
+				sb.WriteString(",\n")
+			}
+			sb.WriteString(indent)
+			sb.WriteString("]")
+		}
+	case map[string]any:
+		sb.WriteString("{\n")
+		for _, k := range sortedKeys(val) {
+			sb.WriteString(innerIndent)
+			sb.WriteString(k)
+			sb.WriteString(" = ")
+			writeHCLValue(sb, val[k], depth+1)
+			sb.WriteString("\n")
+		}
+		sb.WriteString(indent)
+		sb.WriteString("}")
+	}
+}
+
+func sortedKeys(m map[string]any) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/stages/terraform-module-promise/test/stage_test.go
+++ b/stages/terraform-module-promise/test/stage_test.go
@@ -1,7 +1,6 @@
 package run_test
 
 import (
-	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -12,75 +11,57 @@ import (
 	"github.com/onsi/gomega/gexec"
 )
 
-var expectedOutput = `{
-  "module": {
-    "testobject_non-default_test-object": {
-      "source": "git::example.com?ref=1.0.0",
-      "strArr": [
-        {
-          "field": "value"
-        }
-      ],
-      "intArr": [
-        1
-      ],
-      "listBool": [
-        true
-      ],
-      "field": "value",
-      "mapWithinMap": {
-        "entryMap": {
-          "entry": "value",
-          "entry2": 2,
-          "entry3": false
-        },
-        "entry": "value",
-        "entry2": 2,
-        "entry3": false
-      },
-      "number": 7
+var expectedOutput = `module "testobject_non-default_test-object" {
+  source = "git::example.com?ref=1.0.0"
+
+  field = "value"
+  intArr = [1]
+  listBool = [true]
+  mapWithinMap = {
+    entry = "value"
+    entry2 = 2
+    entry3 = false
+    entryMap = {
+      entry = "value"
+      entry2 = 2
+      entry3 = false
     }
   }
+  number = 7
+  strArr = [
+    {
+      field = "value"
+    },
+  ]
 }`
 
-var expectedOutputNoSpec = `{
-  "module": {
-    "testobject_non-default_test-object": {
-      "source": "git::example.com?ref=1.0.0"
-    }
-  }
+var expectedOutputNoSpec = `module "testobject_non-default_test-object" {
+  source = "git::example.com?ref=1.0.0"
 }`
 
-var expectedRegistryOutput = `{
-  "module": {
-    "testobject_non-default_test-object": {
-      "source": "terraform-aws-modules/iam/aws",
-      "version": "6.2.3",
-      "strArr": [
-        {
-          "field": "value"
-        }
-      ],
-      "intArr": [
-        1
-      ],
-      "listBool": [
-        true
-      ],
-      "field": "value",
-      "mapWithinMap": {
-        "entryMap": {
-          "entry": "value",
-          "entry2": 2,
-          "entry3": false
-        },
-        "entry": "value",
-        "entry2": 2,
-        "entry3": false
-      },
-      "number": 7
+var expectedRegistryOutput = `module "testobject_non-default_test-object" {
+  source  = "terraform-aws-modules/iam/aws"
+  version = "6.2.3"
+
+  field = "value"
+  intArr = [1]
+  listBool = [true]
+  mapWithinMap = {
+    entry = "value"
+    entry2 = 2
+    entry3 = false
+    entryMap = {
+      entry = "value"
+      entry2 = 2
+      entry3 = false
     }
   }
+  number = 7
+  strArr = [
+    {
+      field = "value"
+    },
+  ]
 }`
 
 func runWithEnv(envVars map[string]string) *gexec.Session {
@@ -120,22 +101,22 @@ var _ = Describe("From TF module to Promise Stage", func() {
 		It("creates an object file in the output directory", func() {
 			session := runWithEnv(envVars)
 			Eventually(session).Should(gexec.Exit())
-			Expect(session.Buffer()).To(gbytes.Say("Terraform JSON configuration written to %s/testobject_non-default_test-object.tf.json", tmpDir))
+			Expect(session.Buffer()).To(gbytes.Say("Terraform configuration written to %s/testobject_non-default_test-object.tf", tmpDir))
 			Expect(session).To(gexec.Exit(0))
-			output, err := os.ReadFile(filepath.Join(tmpDir, "testobject_non-default_test-object.tf.json"))
+			output, err := os.ReadFile(filepath.Join(tmpDir, "testobject_non-default_test-object.tf"))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(output)).To(MatchJSON(expectedOutput))
+			Expect(string(output)).To(Equal(expectedOutput))
 		})
 
 		It("handles objects without a spec field", func() {
 			envVars["KRATIX_INPUT_FILE"] = "assets/test-object-no-spec.yaml"
 			session := runWithEnv(envVars)
 			Eventually(session).Should(gexec.Exit())
-			Expect(session.Buffer()).To(gbytes.Say("Terraform JSON configuration written to %s/testobject_non-default_test-object.tf.json", tmpDir))
+			Expect(session.Buffer()).To(gbytes.Say("Terraform configuration written to %s/testobject_non-default_test-object.tf", tmpDir))
 			Expect(session).To(gexec.Exit(0))
-			output, err := os.ReadFile(filepath.Join(tmpDir, "testobject_non-default_test-object.tf.json"))
+			output, err := os.ReadFile(filepath.Join(tmpDir, "testobject_non-default_test-object.tf"))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(output)).To(MatchJSON(expectedOutputNoSpec))
+			Expect(string(output)).To(Equal(expectedOutputNoSpec))
 		})
 
 		It("adds a registry version when provided separately", func() {
@@ -143,11 +124,11 @@ var _ = Describe("From TF module to Promise Stage", func() {
 			envVars["MODULE_REGISTRY_VERSION"] = "6.2.3"
 			session := runWithEnv(envVars)
 			Eventually(session).Should(gexec.Exit())
-			Expect(session.Buffer()).To(gbytes.Say("Terraform JSON configuration written to %s/testobject_non-default_test-object.tf.json", tmpDir))
+			Expect(session.Buffer()).To(gbytes.Say("Terraform configuration written to %s/testobject_non-default_test-object.tf", tmpDir))
 			Expect(session).To(gexec.Exit(0))
-			output, err := os.ReadFile(filepath.Join(tmpDir, "testobject_non-default_test-object.tf.json"))
+			output, err := os.ReadFile(filepath.Join(tmpDir, "testobject_non-default_test-object.tf"))
 			Expect(err).NotTo(HaveOccurred())
-			Expect(string(output)).To(MatchJSON(expectedRegistryOutput))
+			Expect(string(output)).To(Equal(expectedRegistryOutput))
 		})
 
 		It("errors when registry version is used with a non-registry source", func() {
@@ -162,25 +143,18 @@ var _ = Describe("From TF module to Promise Stage", func() {
 			envVars["MODULE_OUTPUT_NAMES"] = "s3_bucket_id,s3_bucket_bucket_regional_domain_name"
 			session := runWithEnv(envVars)
 			Eventually(session).Should(gexec.Exit())
-			Expect(session.Buffer()).To(gbytes.Say("Terraform JSON configuration written to %s/testobject_non-default_test-object.tf.json", tmpDir))
+			Expect(session.Buffer()).To(gbytes.Say("Terraform configuration written to %s/testobject_non-default_test-object.tf", tmpDir))
 			Expect(session).To(gexec.Exit(0))
 
-			output, err := os.ReadFile(filepath.Join(tmpDir, "testobject_non-default_test-object.tf.json"))
+			output, err := os.ReadFile(filepath.Join(tmpDir, "testobject_non-default_test-object.tf"))
 			Expect(err).NotTo(HaveOccurred())
-			var parsed map[string]any
-			Expect(json.Unmarshal(output, &parsed)).To(Succeed())
+			outputContent := string(output)
 
-			outputBlock := parsed["output"].(map[string]any)
 			moduleName := "testobject_non-default_test-object"
-			expectedOutputs := map[string]string{
-				moduleName + "_s3_bucket_id":                      "${module." + moduleName + ".s3_bucket_id}",
-				moduleName + "_s3_bucket_bucket_regional_domain_name": "${module." + moduleName + ".s3_bucket_bucket_regional_domain_name}",
-			}
-			for outputName, expectedValue := range expectedOutputs {
-				Expect(outputBlock).To(HaveKey(outputName))
-				Expect(outputBlock[outputName].(map[string]any)["value"]).To(Equal(expectedValue))
-			}
+			Expect(outputContent).To(ContainSubstring(`output "` + moduleName + `_s3_bucket_id"`))
+			Expect(outputContent).To(ContainSubstring(`value = "${module.` + moduleName + `.s3_bucket_id}"`))
+			Expect(outputContent).To(ContainSubstring(`output "` + moduleName + `_s3_bucket_bucket_regional_domain_name"`))
+			Expect(outputContent).To(ContainSubstring(`value = "${module.` + moduleName + `.s3_bucket_bucket_regional_domain_name}"`))
 		})
 	})
-
 })

--- a/stages/terraform-module-promise/test/stage_test.go
+++ b/stages/terraform-module-promise/test/stage_test.go
@@ -14,55 +14,54 @@ import (
 var expectedOutput = `module "testobject_non-default_test-object" {
   source = "git::example.com?ref=1.0.0"
 
-  field = "value"
-  intArr = [1]
+  field    = "value"
+  intArr   = [1]
   listBool = [true]
   mapWithinMap = {
-    entry = "value"
+    entry  = "value"
     entry2 = 2
     entry3 = false
     entryMap = {
-      entry = "value"
+      entry  = "value"
       entry2 = 2
       entry3 = false
     }
   }
   number = 7
-  strArr = [
-    {
-      field = "value"
-    },
-  ]
-}`
+  strArr = [{
+    field = "value"
+  }]
+}
+`
 
 var expectedOutputNoSpec = `module "testobject_non-default_test-object" {
   source = "git::example.com?ref=1.0.0"
-}`
+}
+`
 
 var expectedRegistryOutput = `module "testobject_non-default_test-object" {
   source  = "terraform-aws-modules/iam/aws"
   version = "6.2.3"
 
-  field = "value"
-  intArr = [1]
+  field    = "value"
+  intArr   = [1]
   listBool = [true]
   mapWithinMap = {
-    entry = "value"
+    entry  = "value"
     entry2 = 2
     entry3 = false
     entryMap = {
-      entry = "value"
+      entry  = "value"
       entry2 = 2
       entry3 = false
     }
   }
   number = 7
-  strArr = [
-    {
-      field = "value"
-    },
-  ]
-}`
+  strArr = [{
+    field = "value"
+  }]
+}
+`
 
 func runWithEnv(envVars map[string]string) *gexec.Session {
 	cmd := exec.Command(binaryPath)
@@ -152,9 +151,9 @@ var _ = Describe("From TF module to Promise Stage", func() {
 
 			moduleName := "testobject_non-default_test-object"
 			Expect(outputContent).To(ContainSubstring(`output "` + moduleName + `_s3_bucket_id"`))
-			Expect(outputContent).To(ContainSubstring(`value = "${module.` + moduleName + `.s3_bucket_id}"`))
+			Expect(outputContent).To(ContainSubstring(`value = module.` + moduleName + `.s3_bucket_id`))
 			Expect(outputContent).To(ContainSubstring(`output "` + moduleName + `_s3_bucket_bucket_regional_domain_name"`))
-			Expect(outputContent).To(ContainSubstring(`value = "${module.` + moduleName + `.s3_bucket_bucket_regional_domain_name}"`))
+			Expect(outputContent).To(ContainSubstring(`value = module.` + moduleName + `.s3_bucket_bucket_regional_domain_name`))
 		})
 	})
 })


### PR DESCRIPTION
closes #229

This updates the `ghcr.io/syntasso/kratix-cli/terraform-generate` image to output hcl as opposed to hcl json in resource workflows.

A promise initalised from the `terraform-aws-modules/terraform-aws-s3-bucket` module:

```
kratix init tf-module-promise s3 --module-source "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=v5.10.0" --group example.syntasso.io --kind S3 --version v1alpha1 --dir s3-lib-conversion
```

Generated [the following](https://github.com/syntasso/terraform-gitops/commit/b035f1e9d99680f95cd4191a691779a9af43ab0a) resource request outputs:

```
module "s3_default_example-s3" {
  source = "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=v5.10.0"

  analytics_self_source_destination         = false
  attach_access_log_delivery_policy         = false
  attach_analytics_destination_policy       = false
  attach_cloudtrail_log_delivery_policy     = false
  attach_deny_incorrect_encryption_headers  = false
  attach_deny_incorrect_kms_key_sse         = false
  attach_deny_insecure_transport_policy     = false
  attach_deny_ssec_encrypted_object_uploads = false
  attach_deny_unencrypted_object_uploads    = false
  attach_elb_log_delivery_policy            = false
  attach_inventory_destination_policy       = false
  attach_lb_log_delivery_policy             = false
  attach_policy                             = false
  attach_public_policy                      = true
  attach_require_latest_tls_policy          = false
  attach_waf_log_delivery_policy            = false
  block_public_acls                         = true
  block_public_policy                       = true
  control_object_ownership                  = false
  create_bucket                             = true
  create_metadata_configuration             = false
  force_destroy                             = false
  ignore_public_acls                        = true
  inventory_self_source_destination         = false
  is_directory_bucket                       = false
  object_lock_enabled                       = false
  object_ownership                          = "BucketOwnerEnforced"
  owner                                     = {}
  putin_khuylo                              = true
  restrict_public_buckets                   = true
  skip_destroy_public_access_block          = true
  tags                                      = {}
  type                                      = "Directory"
  versioning                                = {}
}
```

And was applied successfully by [Terraform Cloud](https://app.terraform.io/app/Syntasso/workspaces/terraform-gitops/runs/run-jTVqxHRrYiva9JpD):

<img width="950" height="449" alt="image" src="https://github.com/user-attachments/assets/17afe3fc-0038-4b96-981d-4831d0a975fd" />
