### PR TITLE
ci: auto-merge Dependabot patch and minor (<=2) bumps when unit-test passes

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -1,0 +1,82 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Determine eligibility
+        id: eligible
+        run: |
+          TYPE="${{ steps.metadata.outputs.update-type }}"
+          PREV="${{ steps.metadata.outputs.previous-version }}"
+          NEW="${{ steps.metadata.outputs.new-version }}"
+
+          echo "Update type: $TYPE"
+          echo "Version: $PREV → $NEW"
+
+          if [[ "$TYPE" == "version-update:semver-patch" ]]; then
+            echo "result=true" >> "$GITHUB_OUTPUT"
+            echo "reason=patch bump ($PREV → $NEW)" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [[ "$TYPE" == "version-update:semver-minor" ]]; then
+            PREV_MINOR=$(echo "$PREV" | sed 's/^v//' | cut -d. -f2)
+            NEW_MINOR=$(echo "$NEW" | sed 's/^v//' | cut -d. -f2)
+            DISTANCE=$(( NEW_MINOR - PREV_MINOR ))
+            echo "Minor version distance: $DISTANCE"
+            if [[ $DISTANCE -le 2 ]]; then
+              echo "result=true" >> "$GITHUB_OUTPUT"
+              echo "reason=minor bump, distance ${DISTANCE} ($PREV → $NEW)" >> "$GITHUB_OUTPUT"
+            else
+              echo "result=false" >> "$GITHUB_OUTPUT"
+              echo "reason=minor jump too large (${DISTANCE} versions, max 2) — manual review required" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+
+          echo "result=false" >> "$GITHUB_OUTPUT"
+          echo "reason=major bump — manual review required" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for CI checks
+        if: steps.eligible.outputs.result == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Give unit-test workflow time to register
+          sleep 20
+          gh pr checks ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --watch \
+            --interval 30
+        timeout-minutes: 15
+
+      - name: Merge
+        if: steps.eligible.outputs.result == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Auto-merging: ${{ steps.eligible.outputs.reason }}"
+          gh pr merge ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --squash \
+            --delete-branch
+
+      - name: Skip — not eligible
+        if: steps.eligible.outputs.result != 'true'
+        run: echo "Not auto-merging — ${{ steps.eligible.outputs.reason }}"


### PR DESCRIPTION
Adds a `dependabot-auto-merge` workflow triggered on `pull_request_target` from `dependabot[bot]`.

## Logic

- **Patch bumps** → always auto-merge if CI passes
- **Minor bumps, ≤2 version distance** → auto-merge if CI passes
- **Minor bumps, >2 version distance** → skip, manual review required
- **Major bumps** → skip, manual review required

The workflow waits for the `unit-test` check to pass (via `gh pr checks --watch`) before merging. If checks fail, no merge happens.

## Example outcomes

| Bump | Result |
|---|---|
| `0.5.0 → 0.5.1` patch | ✅ auto-merged |
| `3.18.5 → 3.20.2` minor +2 | ✅ auto-merged |
| `1.68.1 → 1.79.3` minor +11 | ❌ manual |
| any major | ❌ manual |

Part of epic: syntasso/roadmap#125