### PR TITLE
chore: auto-merge all minor dependabot bumps

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -36,17 +36,8 @@ jobs:
           fi
 
           if [[ "$TYPE" == "version-update:semver-minor" ]]; then
-            PREV_MINOR=$(echo "$PREV" | sed 's/^v//' | cut -d. -f2)
-            NEW_MINOR=$(echo "$NEW" | sed 's/^v//' | cut -d. -f2)
-            DISTANCE=$(( NEW_MINOR - PREV_MINOR ))
-            echo "Minor version distance: $DISTANCE"
-            if [[ $DISTANCE -le 2 ]]; then
-              echo "result=true" >> "$GITHUB_OUTPUT"
-              echo "reason=minor bump, distance ${DISTANCE} ($PREV → $NEW)" >> "$GITHUB_OUTPUT"
-            else
-              echo "result=false" >> "$GITHUB_OUTPUT"
-              echo "reason=minor jump too large (${DISTANCE} versions, max 2) — manual review required" >> "$GITHUB_OUTPUT"
-            fi
+            echo "result=true" >> "$GITHUB_OUTPUT"
+            echo "reason=minor bump ($PREV → $NEW)" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 


### PR DESCRIPTION
Removes the minor version distance check (≤2) so all minor bumps auto-merge if CI passes, not just small jumps.

Team is confident in CI as the gate — no version distance limit needed.