### PR TITLE
ci: skip SSH setup for dependabot PRs

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,10 +22,12 @@ jobs:
       - name: Install Terraform CLI
         uses: hashicorp/setup-terraform@v3
       - name: Setup SSH Agent
+        if: github.actor != 'dependabot[bot]'
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SYNTASSO_KRATIX_CLI_PRIVATE_TF_MODULE_TEST_FIXTURE_REPO_DEPLOY_KEY }}
       - name: Setup SSH
+        if: github.actor != 'dependabot[bot]'
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts


### PR DESCRIPTION
Dependabot PRs don't have access to org secrets by default, causing `webfactory/ssh-agent` to fail with an empty key before any tests run. This blocks all Dependabot PRs even when the actual code changes are fine.

Fix: skip the SSH agent setup and `known_hosts` step when the actor is `dependabot[bot]`. The only test that needs SSH is the terraform subdirectory test (`--module-source` with a GitHub URL), which Dependabot PRs don't touch anyway.