### PR TITLE
ci: fix auto-merge deadlock when watching own check

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -49,13 +49,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # Give unit-test workflow time to register
           sleep 20
-          gh pr checks ${{ github.event.pull_request.number }} \
-            --repo ${{ github.repository }} \
-            --watch \
-            --interval 30
-        timeout-minutes: 15
+          PR="${{ github.event.pull_request.number }}"
+          REPO="${{ github.repository }}"
+          for i in $(seq 1 30); do
+            STATUS=$(gh pr checks "$PR" --repo "$REPO" --json name,state,conclusion 2>/dev/null)
+            FAILED=$(echo "$STATUS" | jq '[.[] | select(.name != "auto-merge") | select(.conclusion == "failure" or .conclusion == "cancelled")] | length')
+            PENDING=$(echo "$STATUS" | jq '[.[] | select(.name != "auto-merge") | select(.state == "pending")] | length')
+            echo "Round $i: failed=$FAILED pending=$PENDING"
+            if [ "$FAILED" -gt 0 ]; then
+              echo "CI checks failed"
+              exit 1
+            fi
+            if [ "$PENDING" -eq 0 ]; then
+              echo "All checks passed"
+              exit 0
+            fi
+            sleep 30
+          done
+          echo "Timed out waiting for CI checks"
+          exit 1
+        timeout-minutes: 20
 
       - name: Merge
         if: steps.eligible.outputs.result == 'true'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -22,10 +22,12 @@ jobs:
       - name: Install Terraform CLI
         uses: hashicorp/setup-terraform@v3
       - name: Setup SSH Agent
+        if: github.actor != 'dependabot[bot]'
         uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.SYNTASSO_KRATIX_CLI_PRIVATE_TF_MODULE_TEST_FIXTURE_REPO_DEPLOY_KEY }}
       - name: Setup SSH
+        if: github.actor != 'dependabot[bot]'
         run: |
           mkdir -p ~/.ssh
           ssh-keyscan github.com >> ~/.ssh/known_hosts


### PR DESCRIPTION
## Problem

`gh pr checks --watch` includes the currently-running `auto-merge` job as a pending check, so it waits for itself to finish — deadlock — and hits the 15-minute timeout every time.

## Fix

Replace `--watch` with a manual poll loop that filters out the `auto-merge` check by name, polling every 30 seconds for up to 20 minutes.

## Rollout

Same fix needs applying to: enterprise-kratix, ske-images, helm-charts, kratix-docs, kratix, backstage.