### PR TITLE
ci: handle gh pr checks failure before checks register

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -53,10 +53,16 @@ jobs:
           PR="${{ github.event.pull_request.number }}"
           REPO="${{ github.repository }}"
           for i in $(seq 1 30); do
-            STATUS=$(gh pr checks "$PR" --repo "$REPO" --json name,state,conclusion 2>/dev/null)
+            STATUS=$(gh pr checks "$PR" --repo "$REPO" --json name,state,conclusion 2>/dev/null || echo "[]")
+            TOTAL=$(echo "$STATUS" | jq 'length')
+            if [ "$TOTAL" -eq 0 ]; then
+              echo "Round $i: no checks registered yet"
+              sleep 30
+              continue
+            fi
             FAILED=$(echo "$STATUS" | jq '[.[] | select(.name != "auto-merge") | select(.conclusion == "failure" or .conclusion == "cancelled")] | length')
             PENDING=$(echo "$STATUS" | jq '[.[] | select(.name != "auto-merge") | select(.state == "pending")] | length')
-            echo "Round $i: failed=$FAILED pending=$PENDING"
+            echo "Round $i: failed=$FAILED pending=$PENDING total=$TOTAL"
             if [ "$FAILED" -gt 0 ]; then
               echo "CI checks failed"
               exit 1

--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -53,15 +53,15 @@ jobs:
           PR="${{ github.event.pull_request.number }}"
           REPO="${{ github.repository }}"
           for i in $(seq 1 30); do
-            STATUS=$(gh pr checks "$PR" --repo "$REPO" --json name,state,conclusion 2>/dev/null || echo "[]")
+            STATUS=$(gh pr checks "$PR" --repo "$REPO" --json name,state 2>/dev/null || echo "[]")
             TOTAL=$(echo "$STATUS" | jq 'length')
             if [ "$TOTAL" -eq 0 ]; then
               echo "Round $i: no checks registered yet"
               sleep 30
               continue
             fi
-            FAILED=$(echo "$STATUS" | jq '[.[] | select(.name != "auto-merge") | select(.conclusion == "failure" or .conclusion == "cancelled")] | length')
-            PENDING=$(echo "$STATUS" | jq '[.[] | select(.name != "auto-merge") | select(.state == "pending")] | length')
+            FAILED=$(echo "$STATUS" | jq '[.[] | select(.name != "auto-merge") | select(.state == "FAILURE" or .state == "ERROR" or .state == "CANCELLED")] | length')
+            PENDING=$(echo "$STATUS" | jq '[.[] | select(.name != "auto-merge") | select(.state == "PENDING" or .state == "IN_PROGRESS" or .state == "QUEUED")] | length')
             echo "Round $i: failed=$FAILED pending=$PENDING total=$TOTAL"
             if [ "$FAILED" -gt 0 ]; then
               echo "CI checks failed"


### PR DESCRIPTION
Follow-up to #245. `bash -e` causes immediate exit when `gh pr checks` returns non-zero (e.g. checks haven't registered yet after the PR rebase). Fixes by falling back to `[]` on failure and retrying if no checks are present yet.