### PR TITLE
fix: prevent non-CLI releases from stealing latest tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -46,6 +46,7 @@
       "include-component-in-tag": true,
       "draft": false,
       "prerelease": false,
+      "make-latest": false,
       "release-type": "go",
             "changelog-sections": [
         {
@@ -88,6 +89,7 @@
       "include-component-in-tag": true,
       "draft": false,
       "prerelease": false,
+      "make-latest": false,
       "release-type": "go",
       "changelog-sections": [
         {
@@ -130,6 +132,7 @@
       "include-component-in-tag": true,
       "draft": false,
       "prerelease": false,
+      "make-latest": false,
       "release-type": "go",
       "changelog-sections": [
         {
@@ -172,6 +175,7 @@
       "include-component-in-tag": true,
       "draft": false,
       "prerelease": false,
+      "make-latest": false,
       "release-type": "go",
       "changelog-sections": [
         {
@@ -214,6 +218,7 @@
       "include-component-in-tag": true,
       "draft": false,
       "prerelease": false,
+      "make-latest": false,
       "release-type": "go",
       "changelog-sections": [
         {


### PR DESCRIPTION
## Problem

The repo has multiple release-please components (helm-promise, terraform-module-promise,
crossplane-promise, operator-promise, pulumi-promise) alongside the main CLI. GitHub
marks the most recently published release as latest by default. When any sub-component
releases after the CLI, it steals the \`latest\` tag — demo test scripts that download
assets from \`latest\` then break.

Currently \`terraform-module-promise-v0.7.0\` (Jun 9) is marked latest, not \`v0.17.0\`
(Apr 28).

## Fix

Add \`"make-latest": false\` to all non-root packages in \`release-please-config.json\`.
Only the root package (the actual CLI at \`.\`) will ever claim \`latest\`.

## Immediate fix

\`v0.17.0\` has already been re-marked as latest via \`gh release edit\`.

## Test plan

- [ ] Merge and confirm next sub-component release does not change the latest tag