### PR TITLE
fix: re-pin latest to most recent CLI release after every main push

### DIFF
--- a/.github/workflows/repin-latest-release.yaml
+++ b/.github/workflows/repin-latest-release.yaml
@@ -1,0 +1,22 @@
+name: Re-pin latest CLI release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  repin-latest:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Re-pin latest to most recent CLI release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST_CLI=$(gh release list --repo syntasso/kratix-cli --limit 50 \
+            --json tagName,publishedAt \
+            --jq '[.[] | select(.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | sort_by(.publishedAt) | last | .tagName')
+          echo "Re-pinning latest to $LATEST_CLI"
+          gh release edit "$LATEST_CLI" --repo syntasso/kratix-cli --latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -64,13 +64,3 @@ jobs:
             --token=$TOKEN \
             --repo-url=syntasso/kratix-cli \
             release-pr
-      - name: Re-pin latest to most recent CLI release
-        if: github.ref == 'refs/heads/main'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          LATEST_CLI=$(gh release list --repo syntasso/kratix-cli --limit 50 \
-            --json tagName,publishedAt \
-            --jq '[.[] | select(.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | sort_by(.publishedAt) | last | .tagName')
-          echo "Re-pinning latest to $LATEST_CLI"
-          gh release edit "$LATEST_CLI" --repo syntasso/kratix-cli --latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -64,3 +64,13 @@ jobs:
             --token=$TOKEN \
             --repo-url=syntasso/kratix-cli \
             release-pr
+      - name: Re-pin latest to most recent CLI release
+        if: github.ref == 'refs/heads/main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          LATEST_CLI=$(gh release list --repo syntasso/kratix-cli --limit 50 \
+            --json tagName,publishedAt \
+            --jq '[.[] | select(.tagName | test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))] | sort_by(.publishedAt) | last | .tagName')
+          echo "Re-pinning latest to $LATEST_CLI"
+          gh release edit "$LATEST_CLI" --repo syntasso/kratix-cli --latest


### PR DESCRIPTION
## Problem

The repo has multiple release-please components (helm-promise, terraform-module-promise,
etc.) alongside the main CLI. GitHub marks the most recently published release as latest
by default — any sub-component release after the CLI steals the \`latest\` tag. Demo
test scripts that download assets from \`latest\` then break.

Found: \`terraform-module-promise-v0.7.0\` (Jun 9) had stolen latest from \`v0.17.0\` (Apr 28).

## Fix

Add a step to \`tests.yaml\` that runs on every push to main: finds the most recent CLI
release (tag matching \`^v[0-9]+\.[0-9]+\.[0-9]+$\`) and marks it as latest. Idempotent
— safe to run even when CLI is already latest.

## Verified

Tested the `gh release list` + `gh release edit --latest` logic locally against the
live repo — correctly identifies v0.17.0 and the edit call succeeds.