### PR TITLE
fix: use commit check-runs API and add circuit breaker for empty checks

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -82,16 +82,29 @@ jobs:
           sleep 20
           PR="${{ github.event.pull_request.number }}"
           REPO="${{ github.repository }}"
-          for i in $(seq 1 60); do
-            STATUS=$(gh pr checks "$PR" --repo "$REPO" --json name,state 2>/dev/null || echo "[]")
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          EMPTY_ROUNDS=0
+          for i in $(seq 1 120); do
+            STATUS=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs?per_page=100" \
+              --jq '[.check_runs[] | {name: .name, state: (if .conclusion != null then (.conclusion | ascii_upcase) else (.status | ascii_upcase) end)}]' \
+              2>/dev/null || echo "[]")
             TOTAL=$(echo "$STATUS" | jq 'length')
             if [ "$TOTAL" -eq 0 ]; then
-              echo "Round $i: no checks registered yet"
+              EMPTY_ROUNDS=$((EMPTY_ROUNDS + 1))
+              echo "Round $i: no checks registered yet (${EMPTY_ROUNDS} consecutive empty rounds)"
+              if [ "$EMPTY_ROUNDS" -ge 10 ]; then
+                gh pr comment "$PR" --repo "$REPO" \
+                  --body "⚠️ **auto-merge**: CI checks unreadable after 5 minutes. Possible GitHub API issue — check CI manually and merge if green." \
+                  2>/dev/null || true
+                echo "Circuit breaker: exiting after $EMPTY_ROUNDS empty rounds"
+                exit 1
+              fi
               sleep 30
               continue
             fi
-            FAILED=$(echo "$STATUS" | jq '[.[] | select(.name != "auto-merge") | select(.state == "FAILURE" or .state == "ERROR" or .state == "CANCELLED")] | length')
-            PENDING=$(echo "$STATUS" | jq '[.[] | select(.name != "auto-merge") | select(.state == "PENDING" or .state == "IN_PROGRESS" or .state == "QUEUED")] | length')
+            EMPTY_ROUNDS=0
+            FAILED=$(echo "$STATUS" | jq '[.[] | select(.name != "auto-merge") | select(.state == "FAILURE" or .state == "TIMED_OUT" or .state == "CANCELLED" or .state == "ACTION_REQUIRED")] | length')
+            PENDING=$(echo "$STATUS" | jq '[.[] | select(.name != "auto-merge") | select(.state == "IN_PROGRESS" or .state == "QUEUED" or .state == "PENDING" or .state == "WAITING")] | length')
             echo "Round $i: failed=$FAILED pending=$PENDING total=$TOTAL"
             if [ "$FAILED" -gt 0 ]; then
               echo "CI checks failed"
@@ -105,13 +118,14 @@ jobs:
           done
           echo "Timed out waiting for CI checks"
           exit 1
-        timeout-minutes: 35
+        timeout-minutes: 65
 
       - name: Merge
         if: steps.eligible.outputs.result == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          echo "Auto-merging: ${{ steps.eligible.outputs.reason }}"
           gh pr merge ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
             --squash \


### PR DESCRIPTION
## Problem

`gh pr checks` uses GitHub's GraphQL PR-level check aggregation, which has eventual consistency lag vs the underlying commit check-runs API. In 5 observed failures (enterprise-kratix ×3, backstage ×2, kratix-cli ×1), `gh pr checks` returned empty for the entire 30-minute window even though checks had registered on the commit within seconds. This caused silent timeouts with no actionable output.

## Fix

1. **Switch to commit check-runs REST endpoint** (`/commits/{sha}/check-runs`) — more consistent than the PR-level GraphQL aggregation used by `gh pr checks`.

2. **Circuit breaker** — if checks stay empty for 10 consecutive rounds (5 minutes), post a comment on the PR and exit fast rather than waiting the full 60 minutes.

## Behaviour change

- Empty-check glitch now fails in ~5 min with a PR comment instead of silently timing out after 30–60 min.
- Genuine slow CI still waits up to 60 min before timing out.
- State mapping updated to cover `TIMED_OUT` and `ACTION_REQUIRED` as failure states.