### PR TITLE
ci: add commitlint to enforce conventional commit messages

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["@commitlint/config-conventional"],
+  "rules": {
+    "type-enum": [2, "always", ["feat", "fix", "docs", "chore", "ci", "test", "build", "style", "refactor"]]
+  }
+}

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -8,6 +8,7 @@ on:
       - synchronize
 
 permissions:
+  contents: read
   pull-requests: read
 
 jobs:

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -18,6 +18,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: wagoid/commitlint-github-action@v6
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed  # v6.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -1,0 +1,23 @@
+name: Lint commit messages
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  commitlint:
+    name: Lint commit messages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.commitlintrc.json` restricting commit types to `feat`, `fix`, `docs`, `chore`, `ci`, `test`, `build`, `style`, `refactor` (matches existing PR title validator)
- Adds `.github/workflows/commitlint.yaml` running `wagoid/commitlint-github-action@v6` on PR open/sync

## Why
PR title validation already enforces conventional commits at the squash boundary. This adds enforcement at the individual commit level so the full history stays clean.