### PR TITLE
chore: disable body/footer line-length limits and skip dependabot in commitlint

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,6 +1,8 @@
 {
   "extends": ["@commitlint/config-conventional"],
   "rules": {
-    "type-enum": [2, "always", ["feat", "fix", "docs", "chore", "ci", "test", "build", "style", "refactor"]]
+    "type-enum": [2, "always", ["feat", "fix", "docs", "chore", "ci", "test", "build", "style", "refactor"]],
+    "body-max-line-length": [0],
+    "footer-max-line-length": [0]
   }
 }

--- a/.github/workflows/commitlint.yaml
+++ b/.github/workflows/commitlint.yaml
@@ -14,6 +14,7 @@ permissions:
 jobs:
   commitlint:
     name: Lint commit messages
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Dependabot commit bodies exceed the default 100-char `body-max-line-length` rule, causing spurious lint failures on valid PRs. Two fixes:

- Disable `body-max-line-length` and `footer-max-line-length` (set to `[0]`) — machine-generated and long URLs are not worth enforcing line length on
- Skip the commitlint job entirely for `dependabot[bot]` — it always uses `chore(deps):` format, linting adds zero value